### PR TITLE
Dialogues.md

### DIFF
--- a/NPCAsset/Dialogues.md
+++ b/NPCAsset/Dialogues.md
@@ -1,0 +1,47 @@
+Dialogue
+========
+
+**GUID** *32-digit hexadecimal*: Refer to [GUID](/GUID.md) documentation.
+
+**Type** *enum* (`Dialogue`)
+
+**ID** *uint16*: Must be a unique identifier. Values less than 2,000 are reserved for official content.
+
+Messages
+--------
+
+Properties pertaining to dialogue performed by the NPC. Dialogue can utilize conditions and rewards. Messages that meet all of their conditions will be shown, and can grant rewards when the message is shown. These are prefixed with `Message_#_`. For example, `Message_0_Condition_0_Type Flag_Bool`. Refer to [Conditions.md](/NPCAsset/Conditions.md) and [Rewards.md](/NPCAsset/Rewards.md) for additional documentation.
+
+**Messages** *int32*: Total number of possible messages.
+
+**Message\_#\_Pages** *byte*: Total number of pages the message has.
+
+**Message\_#\_Responses** *byte*: Total number of responses to be shown when this message is shown. If 0, then all messages are automatically a candidate to be shown. Defaults to 0.
+
+**Message\_#\_Response\_#** *byte*: Index of the response to show.
+
+**Message\_#\_Prev** *uint16*: ID of dialogue to return to if there are no responses available for this message. Defaults to 0.
+
+Responses
+---------
+
+Properties pertaining to dialogue available to the player. Dialogue can utilize conditions and rewards. Responses are only visible when conditions are met, and can grant rewards when selected. These are prefixed with `Response_#_`. For example, `Response_0_Reward_0_Type Quest`. Refer to [Conditions.md](/NPCAsset/Conditions.md) and [Rewards.md](/NPCAsset/Rewards.md) for additional documentation.
+
+**Responses** *byte*: Total number of possible responses.
+
+**Response\_#\_Messages** *byte*: Total number of messages to only show this response for. If 0, then it is shown for all messages. Defaults to 0.
+
+**Response\_#\_Message\_#** *uint16*: Index of the message to show for.
+
+**Response\_#\_Dialogue** *uint16*: ID of the dialogue to open when selected.
+
+**Response\_#\_Quest** *uint16*: ID of the quest to preview when selected.
+
+**Response\_#\_Vendor** *uint16*: ID of the vendor to open when selected.
+
+Localization
+------------
+
+**Message\_#\_Page\_#**: Text shown for the corresponding message page.
+
+**Response\_#**: Text shown for the corresponding response option.


### PR DESCRIPTION
Documentation for NPC dialogue assets. Serves as a replacement of the original Steam Guide documentation for NPCs.