### PR TITLE
ItemAsset documentation (Grips/Barrels, +revisions)

### DIFF
--- a/ItemAsset/BarrelAsset.md
+++ b/ItemAsset/BarrelAsset.md
@@ -36,8 +36,14 @@ Caliber Asset Properties
 Barrel Asset Properties
 -----------------------
 
-**Braked**: Specified if a muzzle flash is hidden.
+**Ballistic_Drop** *float*: Multiplier on ballistic drop. Defaults to 1.
 
-**Silenced**: Specified if alerts are not generated.
+**Braked** *bool*: Specified if a muzzle flash should be hidden.
 
-**Volume**: Amount to multiply gunfire sound volume.
+**Durability** *byte*: Amount of quality lost after each firing of the ranged weapon. When this value is greater than 0, the item always has a visible item quality shown. Defaults to 0.
+
+**Gunshot_Rolloff_Distance_Multiplier** *float*: Multiplier on gunshot rolloff distance. Defaults to 0.5 if Silenced, otherwise to 1.
+
+**Silenced** *bool*: Specified if alerts should not be generated.
+
+**Volume** *float*: Multiplier on gunfire sound volume.

--- a/ItemAsset/BarrelAsset.md
+++ b/ItemAsset/BarrelAsset.md
@@ -1,0 +1,43 @@
+Barrel Assets
+=============
+
+Barrel attachments are inventory items that can be attached to ranged weapons.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to [GUID](/GUID.md) documentation.
+
+**Type** *enum* (`Barrel`)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Caliber Asset Properties
+------------------------
+
+**Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
+
+**Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
+
+**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
+
+**Paintable** *bool*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
+
+**Recoil_X** *float*: Multiplier on horizontal recoil.
+
+**Recoil_Y** *float*: Multiplier on vertical recoil.
+
+**Shake** *float*: Multiplier on shake.
+
+**Spread** *float*: Multiplier on spread.
+
+**Sway** *float*: Multiplier on sway.
+
+Barrel Asset Properties
+-----------------------
+
+**Braked**: Specified if a muzzle flash is hidden.
+
+**Silenced**: Specified if alerts are not generated.
+
+**Volume**: Amount to multiply gunfire sound volume.

--- a/ItemAsset/GripAsset.md
+++ b/ItemAsset/GripAsset.md
@@ -1,0 +1,53 @@
+Grip Assets
+============
+
+Grip attachments are inventory items that can be attached to ranged weapons.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to [GUID](/GUID.md) documentation.
+
+**Type** *enum* (`Grip`)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Caliber Asset Properties
+------------------------
+
+**Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
+
+**Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
+
+**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
+
+**Paintable** *bool*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
+
+**Recoil_X** *float*: Multiplier on horizontal recoil.
+
+**Recoil_Y** *float*: Multiplier on vertical recoil.
+
+**Shake** *float*: Multiplier on shake.
+
+**Spread** *float*: Multiplier on spread.
+
+**Sway** *float*: Multiplier on sway.
+
+Grip Asset Properties
+---------------------
+
+**Damage** *float*: Multiplier on damage.
+
+**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
+
+**Laser** *bool*: Provides a toggleable laser.
+
+**Light** *bool*: Provides a toggleable flashlight.
+
+**Melee** *bool*: Provides the ability to perform a melee attack.
+
+
+
+__Type__: `Grip`
+
+__Bipod__: Specified if effects only take place when prone.

--- a/ItemAsset/GripAsset.md
+++ b/ItemAsset/GripAsset.md
@@ -36,18 +36,4 @@ Caliber Asset Properties
 Grip Asset Properties
 ---------------------
 
-**Damage** *float*: Multiplier on damage.
-
-**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
-
-**Laser** *bool*: Provides a toggleable laser.
-
-**Light** *bool*: Provides a toggleable flashlight.
-
-**Melee** *bool*: Provides the ability to perform a melee attack.
-
-
-
-__Type__: `Grip`
-
-__Bipod__: Specified if effects only take place when prone.
+**Bipod** *bool*: Specified if effects should only take place while prone.

--- a/ItemAsset/MapAsset.md
+++ b/ItemAsset/MapAsset.md
@@ -1,5 +1,5 @@
 Map Assets
-=============
+==========
 
 Maps and compasses provide the player with additional UI information for as long as they are in the player's inventory. They can neither be held nor equipped.
 
@@ -13,7 +13,7 @@ Item Asset Properties
 **ID** *uint16*: Must be a unique identifier.
 
 Map Asset Properties
------------------------
+--------------------
 
 **Enables_Map**: Provides access to a satellite map display.
 

--- a/ItemAsset/README.md
+++ b/ItemAsset/README.md
@@ -5,7 +5,7 @@ Item assets are an [Assets v1](/AssetsV1.md) class. See [AssetBundles.md](/Asset
 
 **GUID** *32-digit hexadecimal*: Refer to [GUID](/GUID.md) documentation.
 
-**Type** *enum* (`Arrest_End`, `Arrest_Start`, `Backpack`, `Barrel`, `Barricade`, `Beacon`, `Box`, `Charge`, `Cloud`, [`Compass`](/ItemAsset/MapAsset.md), `Detonator`, `Farm`, `Filter`, `Fisher`, `Food`, `Fuel`, `Generator`, `Glasses`, `Grip`, `Grower`, `Gun`, `Hat`, `Key`, `Library`, `Magazine`, [`Map`](/ItemAsset/MapAsset.md), `Mask`, `Medical`, `Melee`, `Oil_Pump`, `Optic`, `Pants`, `Refill`, `Sentry`, `Shirt`, [`Sight`](/ItemAsset/SightAsset.md), `Storage`, `Structure`, [`Supply`](/ItemAsset/SupplyAsset.md), [`Tactical`](/ItemAsset/TacticalAsset.md), `Tank`, `Throwable`, `Tire`, `Tool`, `Trap`, `Vehicle_Repair_Tool`, `Vest`, `Water`)
+**Type** *enum* (`Arrest_End`, `Arrest_Start`, `Backpack`, [`Barrel`](/ItemAsset/BarrelAsset.md), `Barricade`, `Beacon`, `Box`, `Charge`, `Cloud`, [`Compass`](/ItemAsset/MapAsset.md), `Detonator`, `Farm`, `Filter`, `Fisher`, `Food`, `Fuel`, `Generator`, `Glasses`, [`Grip`](/ItemAsset/GripAsset.md), `Grower`, `Gun`, `Hat`, `Key`, `Library`, `Magazine`, [`Map`](/ItemAsset/MapAsset.md), `Mask`, `Medical`, `Melee`, `Oil_Pump`, `Optic`, `Pants`, `Refill`, `Sentry`, `Shirt`, [`Sight`](/ItemAsset/SightAsset.md), `Storage`, `Structure`, [`Supply`](/ItemAsset/SupplyAsset.md), [`Tactical`](/ItemAsset/TacticalAsset.md), `Tank`, `Throwable`, `Tire`, `Tool`, `Trap`, `Vehicle_Repair_Tool`, `Vest`, `Water`)
 
 **Rarity** *enum* (`Common`, `Uncommon`, `Rare`, `Epic`, `Legendary`, `Mythical`): Rarity of the item, as text shown in menus and colors used for highlights. Defaults to Common rarity.
 

--- a/ItemAsset/SightAsset.md
+++ b/ItemAsset/SightAsset.md
@@ -6,7 +6,7 @@ Sight attachments are inventory items that can be attached to ranged weapons.
 Item Asset Properties
 ---------------------
 
-**GUID** *32-digit hexadecimal*: Refer to [/GUID](GUID.md) documentation.
+**GUID** *32-digit hexadecimal*: Refer to [GUID](/GUID.md) documentation.
 
 **Type** *enum* (`Sight`)
 

--- a/ItemAsset/SightAsset.md
+++ b/ItemAsset/SightAsset.md
@@ -6,11 +6,32 @@ Sight attachments are inventory items that can be attached to ranged weapons.
 Item Asset Properties
 ---------------------
 
-**GUID** *32-digit hexadecimal*: Refer to [GUID](/GUID.md) documentation.
+**GUID** *32-digit hexadecimal*: Refer to [/GUID](GUID.md) documentation.
 
 **Type** *enum* (`Sight`)
 
 **ID** *uint16*: Must be a unique identifier.
+
+Caliber Asset Properties
+------------------------
+
+**Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
+
+**Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
+
+**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
+
+**Paintable** *bool*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
+
+**Recoil_X** *float*: Multiplier on horizontal recoil.
+
+**Recoil_Y** *float*: Multiplier on vertical recoil.
+
+**Shake** *float*: Multiplier on shake.
+
+**Spread** *float*: Multiplier on spread.
+
+**Sway** *float*: Multiplier on sway.
 
 Sight Asset Properties
 ----------------------

--- a/ItemAsset/TacticalAsset.md
+++ b/ItemAsset/TacticalAsset.md
@@ -12,20 +12,16 @@ Item Asset Properties
 
 **ID** *uint16*: Must be a unique identifier.
 
-Tactical Asset Properties
--------------------------
+Caliber Asset Properties
+------------------------
 
-**Damage** *float*: Multiplier on damage.
+**Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
+
+**Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
 
 **Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
 
-**Laser** *bool*: Provides a toggleable laser.
-
-**Light** *bool*: Provides a toggleable flashlight.
-
-**Melee** *bool*: Provides the ability to perform a melee attack.
-
-**Rangefinder** *bool*: Provides a toggleable rangefinder.
+**Paintable** *bool*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
 
 **Recoil_X** *float*: Multiplier on horizontal recoil.
 
@@ -34,3 +30,16 @@ Tactical Asset Properties
 **Shake** *float*: Multiplier on shake.
 
 **Spread** *float*: Multiplier on spread.
+
+**Sway** *float*: Multiplier on sway.
+
+Tactical Asset Properties
+-------------------------
+
+**Laser** *bool*: Provides a toggleable laser.
+
+**Light** *bool*: Provides a toggleable flashlight.
+
+**Melee** *bool*: Provides the ability to perform a melee attack.
+
+**Rangefinder** *bool*: Provides a toggleable rangefinder.


### PR DESCRIPTION
Creates the **BarrelAsset.md** and **GripAsset.md** documentation files for barrel attachments and grip attachments.

Revises all other attachment documentation to separate CaliberAsset properties from the item's unique properties. Added missing CaliberAsset properties.

Copyediting for any other ItemAsset documentation files with new commits.