### PR TITLE
Add missing Calibers and Caliber_# properties

### DIFF
--- a/ItemAsset/BarrelAsset.md
+++ b/ItemAsset/BarrelAsset.md
@@ -17,6 +17,10 @@ Caliber Asset Properties
 
 **Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
 
+**Calibers** *uint16*: Total amount of unique calibers.
+
+**Caliber_#** *uint16*: Caliber ID for acceptable attachment compatibility.
+
 **Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
 
 **Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.

--- a/ItemAsset/GripAsset.md
+++ b/ItemAsset/GripAsset.md
@@ -17,6 +17,10 @@ Caliber Asset Properties
 
 **Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
 
+**Calibers** *uint16*: Total amount of unique calibers.
+
+**Caliber_#** *uint16*: Caliber ID for acceptable attachment compatibility.
+
 **Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
 
 **Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.

--- a/ItemAsset/SightAsset.md
+++ b/ItemAsset/SightAsset.md
@@ -17,6 +17,10 @@ Caliber Asset Properties
 
 **Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
 
+**Calibers** *uint16*: Total amount of unique calibers.
+
+**Caliber_#** *uint16*: Caliber ID for acceptable attachment compatibility.
+
 **Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
 
 **Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.

--- a/ItemAsset/TacticalAsset.md
+++ b/ItemAsset/TacticalAsset.md
@@ -17,6 +17,10 @@ Caliber Asset Properties
 
 **Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
 
+**Calibers** *uint16*: Total amount of unique calibers.
+
+**Caliber_#** *uint16*: Caliber ID for acceptable attachment compatibility.
+
 **Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
 
 **Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.


### PR DESCRIPTION
Adds two caliber asset properties that were missing from the four attachment asset docs. 

**Calibers** *uint16*: Total amount of unique calibers.

**Caliber_#** *uint16*: Caliber ID for acceptable attachment compatibility.