### PR TITLE
Target_Loss_Radius

### DIFF
--- a/ItemAsset/SentryAsset.md
+++ b/ItemAsset/SentryAsset.md
@@ -1,0 +1,6 @@
+Sentry Assets
+=============
+
+Noting these here for now until sentry properties are documented:
+
+**Target_Loss_Radius** *float*: Radius for tracking targets after they leave the initial detection radius. Defaults to 20% higher than Detection_Radius.


### PR DESCRIPTION
As per the 3.21.33.0 Update (sentry guns do not lose targets immediately outside detection radius).