### PR TITLE
Hatnote to redirect readers to the updated docs

### DIFF
--- a/ItemData.md
+++ b/ItemData.md
@@ -1,3 +1,5 @@
+**NOTE:** This documentation file has been deprecated in favor of the [ItemAsset directory](/ItemAsset).
+
 __Items__ in _Unturned_ encompass anything that can be carried in a player's in-game inventory. All items share some properties, while each item type has its own unique data. All of the data applicable to each possible item type can be found below.
 
 - [Non-specific Data](#Non-specific-Data)


### PR DESCRIPTION
Adds a note to the top of ItemData.md, which tells readers that this doc file is deprecated, and up-to-date docs can be found in the ItemAsset directory.