### PR TITLE
CaliberAsset.md and inheritance

### DIFF
--- a/ItemAsset/BarrelAsset.md
+++ b/ItemAsset/BarrelAsset.md
@@ -3,7 +3,7 @@ Barrel Assets
 
 Barrel attachments are inventory items that can be attached to ranged weapons.
 
-Inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
+This inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
 
 Item Asset Properties
 ---------------------
@@ -13,31 +13,6 @@ Item Asset Properties
 **Type** *enum* (`Barrel`)
 
 **ID** *uint16*: Must be a unique identifier.
-
-Caliber Asset Properties
-------------------------
-
-**Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
-
-**Calibers** *uint16*: Total amount of unique calibers.
-
-**Caliber_#** *uint16*: Caliber ID for acceptable attachment compatibility.
-
-**Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
-
-**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
-
-**Paintable** *bool*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
-
-**Recoil_X** *float*: Multiplier on horizontal recoil.
-
-**Recoil_Y** *float*: Multiplier on vertical recoil.
-
-**Shake** *float*: Multiplier on shake.
-
-**Spread** *float*: Multiplier on spread.
-
-**Sway** *float*: Multiplier on sway.
 
 Barrel Asset Properties
 -----------------------

--- a/ItemAsset/BarrelAsset.md
+++ b/ItemAsset/BarrelAsset.md
@@ -3,6 +3,8 @@ Barrel Assets
 
 Barrel attachments are inventory items that can be attached to ranged weapons.
 
+Inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
+
 Item Asset Properties
 ---------------------
 

--- a/ItemAsset/CaliberAsset.md
+++ b/ItemAsset/CaliberAsset.md
@@ -1,0 +1,29 @@
+Caliber Assets
+==============
+
+This inherits the [ItemAsset](/ItemAsset/README.md) class.
+
+Caliber Asset Properties
+------------------------
+
+**Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
+
+**Calibers** *uint16*: Total amount of unique calibers.
+
+**Caliber_#** *uint16*: Caliber ID for acceptable attachment compatibility.
+
+**Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
+
+**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
+
+**Paintable** *bool*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
+
+**Recoil_X** *float*: Multiplier on horizontal recoil.
+
+**Recoil_Y** *float*: Multiplier on vertical recoil.
+
+**Shake** *float*: Multiplier on shake.
+
+**Spread** *float*: Multiplier on spread.
+
+**Sway** *float*: Multiplier on sway.

--- a/ItemAsset/GripAsset.md
+++ b/ItemAsset/GripAsset.md
@@ -3,6 +3,8 @@ Grip Assets
 
 Grip attachments are inventory items that can be attached to ranged weapons.
 
+Inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
+
 Item Asset Properties
 ---------------------
 

--- a/ItemAsset/GripAsset.md
+++ b/ItemAsset/GripAsset.md
@@ -3,7 +3,7 @@ Grip Assets
 
 Grip attachments are inventory items that can be attached to ranged weapons.
 
-Inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
+This inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
 
 Item Asset Properties
 ---------------------
@@ -13,31 +13,6 @@ Item Asset Properties
 **Type** *enum* (`Grip`)
 
 **ID** *uint16*: Must be a unique identifier.
-
-Caliber Asset Properties
-------------------------
-
-**Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
-
-**Calibers** *uint16*: Total amount of unique calibers.
-
-**Caliber_#** *uint16*: Caliber ID for acceptable attachment compatibility.
-
-**Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
-
-**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
-
-**Paintable** *bool*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
-
-**Recoil_X** *float*: Multiplier on horizontal recoil.
-
-**Recoil_Y** *float*: Multiplier on vertical recoil.
-
-**Shake** *float*: Multiplier on shake.
-
-**Spread** *float*: Multiplier on spread.
-
-**Sway** *float*: Multiplier on sway.
 
 Grip Asset Properties
 ---------------------

--- a/ItemAsset/MagazineAsset.md
+++ b/ItemAsset/MagazineAsset.md
@@ -3,7 +3,7 @@ Magazine Assets
 
 Magazine attachments are inventory items that can be attached to ranged weapons.
 
-Inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
+This inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
 
 Item Asset Properties
 ---------------------
@@ -13,31 +13,6 @@ Item Asset Properties
 **Type** *enum* (`Magazine`)
 
 **ID** *uint16*: Must be a unique identifier.
-
-Caliber Asset Properties
-------------------------
-
-**Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
-
-**Calibers** *uint16*: Total amount of unique calibers.
-
-**Caliber_#** *uint16*: Caliber ID for acceptable attachment compatibility.
-
-**Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
-
-**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
-
-**Paintable** *bool*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
-
-**Recoil_X** *float*: Multiplier on horizontal recoil.
-
-**Recoil_Y** *float*: Multiplier on vertical recoil.
-
-**Shake** *float*: Multiplier on shake.
-
-**Spread** *float*: Multiplier on spread.
-
-**Sway** *float*: Multiplier on sway.
 
 Magazine Asset Properties
 -------------------------

--- a/ItemAsset/MagazineAsset.md
+++ b/ItemAsset/MagazineAsset.md
@@ -3,6 +3,8 @@ Magazine Assets
 
 Magazine attachments are inventory items that can be attached to ranged weapons.
 
+Inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
+
 Item Asset Properties
 ---------------------
 

--- a/ItemAsset/MapAsset.md
+++ b/ItemAsset/MapAsset.md
@@ -3,6 +3,8 @@ Map Assets
 
 Maps and compasses provide the player with additional UI information for as long as they are in the player's inventory. They can neither be held nor equipped.
 
+Inherits the [ItemAsset](/ItemAsset/README.md) class.
+
 Item Asset Properties
 ---------------------
 

--- a/ItemAsset/MapAsset.md
+++ b/ItemAsset/MapAsset.md
@@ -3,7 +3,7 @@ Map Assets
 
 Maps and compasses provide the player with additional UI information for as long as they are in the player's inventory. They can neither be held nor equipped.
 
-Inherits the [ItemAsset](/ItemAsset/README.md) class.
+This inherits the [ItemAsset](/ItemAsset/README.md) class.
 
 Item Asset Properties
 ---------------------

--- a/ItemAsset/SightAsset.md
+++ b/ItemAsset/SightAsset.md
@@ -3,6 +3,8 @@ Sight Assets
 
 Sight attachments are inventory items that can be attached to ranged weapons.
 
+Inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
+
 Item Asset Properties
 ---------------------
 

--- a/ItemAsset/SightAsset.md
+++ b/ItemAsset/SightAsset.md
@@ -3,7 +3,7 @@ Sight Assets
 
 Sight attachments are inventory items that can be attached to ranged weapons.
 
-Inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
+This inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
 
 Item Asset Properties
 ---------------------
@@ -13,31 +13,6 @@ Item Asset Properties
 **Type** *enum* (`Sight`)
 
 **ID** *uint16*: Must be a unique identifier.
-
-Caliber Asset Properties
-------------------------
-
-**Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
-
-**Calibers** *uint16*: Total amount of unique calibers.
-
-**Caliber_#** *uint16*: Caliber ID for acceptable attachment compatibility.
-
-**Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
-
-**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
-
-**Paintable** *bool*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
-
-**Recoil_X** *float*: Multiplier on horizontal recoil.
-
-**Recoil_Y** *float*: Multiplier on vertical recoil.
-
-**Shake** *float*: Multiplier on shake.
-
-**Spread** *float*: Multiplier on spread.
-
-**Sway** *float*: Multiplier on sway.
 
 Sight Asset Properties
 ----------------------

--- a/ItemAsset/SupplyAsset.md
+++ b/ItemAsset/SupplyAsset.md
@@ -3,7 +3,7 @@ Supply Assets
 
 Crafting supplies are items primarily intended to be used as ingredients in crafting blueprints. They can neither be held nor equipped.
 
-Inherits the [ItemAsset](/ItemAsset/README.md) class.
+This inherits the [ItemAsset](/ItemAsset/README.md) class.
 
 Item Asset Properties
 ---------------------

--- a/ItemAsset/SupplyAsset.md
+++ b/ItemAsset/SupplyAsset.md
@@ -3,6 +3,8 @@ Supply Assets
 
 Crafting supplies are items primarily intended to be used as ingredients in crafting blueprints. They can neither be held nor equipped.
 
+Inherits the [ItemAsset](/ItemAsset/README.md) class.
+
 Item Asset Properties
 ---------------------
 

--- a/ItemAsset/TacticalAsset.md
+++ b/ItemAsset/TacticalAsset.md
@@ -3,6 +3,8 @@ Tactical Assets
 
 Tactical attachments are inventory items that can be attached to ranged weapons.
 
+Inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
+
 Item Asset Properties
 ---------------------
 

--- a/ItemAsset/TacticalAsset.md
+++ b/ItemAsset/TacticalAsset.md
@@ -3,7 +3,7 @@ Tactical Assets
 
 Tactical attachments are inventory items that can be attached to ranged weapons.
 
-Inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
+This inherits the [CaliberAsset](/ItemAsset/CaliberAsset.md) class.
 
 Item Asset Properties
 ---------------------
@@ -13,31 +13,6 @@ Item Asset Properties
 **Type** *enum* (`Tactical`)
 
 **ID** *uint16*: Must be a unique identifier.
-
-Caliber Asset Properties
-------------------------
-
-**Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
-
-**Calibers** *uint16*: Total amount of unique calibers.
-
-**Caliber_#** *uint16*: Caliber ID for acceptable attachment compatibility.
-
-**Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
-
-**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
-
-**Paintable** *bool*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
-
-**Recoil_X** *float*: Multiplier on horizontal recoil.
-
-**Recoil_Y** *float*: Multiplier on vertical recoil.
-
-**Shake** *float*: Multiplier on shake.
-
-**Spread** *float*: Multiplier on spread.
-
-**Sway** *float*: Multiplier on sway.
 
 Tactical Asset Properties
 -------------------------


### PR DESCRIPTION
Moves documentation of **Caliber Assets** out of docs such as **SightAsset.md** and **GripAsset.md**. Instead, creates a new doc called **CaliberAsset.md**.

Then, adds a "**This inherits the XYZ class.**" note to the lead section of each item asset, which links to its parent class.

The latest commit only lists the direct parent, and doesn't take into account multilevel inheritance (e.g., GripAsset → CaliberAsset → ItemAsset). But, we could change this so that all relevant parents are taken into account, if you feel that'd be more helpful.

I.e., "**This inherits the CaliberAsset, and ItemAsset classes.**"

---

**Further thoughts:** My thought process with creating CaliberAsset.md is that this will reduce repeated/duplicate information, and thus make maintaining the docs simpler. Classes such as ItemBarricadeAsset, ItemWeaponAsset, ItemCaliberAsset, ItemClothingAsset, and ItemConsumeableAsset would result in a lot of repeated information otherwise.