### PR TITLE
Arid workshop ID

### DIFF
--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -175,6 +175,7 @@ Curated maps are available as workshop items, so are configured in the `Workshop
 Alphabetically sorted list of curated map file IDs:
 
 - Athens Arena: 1454125991
+- Arid: 2683620106
 - Belgium: 1727125581
 - Bunker Arena: 1257784170
 - California: 1905768396


### PR DESCRIPTION
Adds the Arid map to the list of Workshop IDs in the server hosting guide.