### PR TITLE
Fixed data type, listed enumerators, & prefixes/names clarity

### DIFF
--- a/NPCAsset/Conditions.md
+++ b/NPCAsset/Conditions.md
@@ -1,7 +1,7 @@
 Conditions
 ==========
 
-Conditions can be held by NPC assets, interactable objects, and item blueprints. The specific property prefix may differ between asset types.
+Conditions can be held by NPC assets, interactable objects, and item blueprints. The specific property prefix may differ between asset types. For example, quests may use "Conditions" while blueprints use "Blueprint_#\_Conditions".
 
 **Conditions** *byte*: Total number of conditions.
 

--- a/NPCAsset/Conditions.md
+++ b/NPCAsset/Conditions.md
@@ -3,9 +3,9 @@ Conditions
 
 Conditions can be held by NPC assets, interactable objects, and item blueprints.
 
-**Conditions** *int*: Total number of conditions.
+**Conditions** *byte*: Total number of conditions.
 
-**Condition\_#\_Type** *enum*
+**Condition\_#\_Type** *enum* (`Compare_Flags`, `Flag_Bool`, `Flag_Short`, `Currency`, `Experience`, `Item`, `Kills_Animal`, `Kills_Horde`, `Kills_Object`, `Kills_Player`, `Kills_Tree`, `Kills_Resource`, `Player_Life_Food`, `Player_Life_Health`, `Player_Life_Virus`, `Player_Life_Water`, `Quest`, `Reputation`, `Skillset`, `Holiday`, `Time_Of_Day`, `Weather_Blend_Alpha`, `Weather_Status`)
 
 **Condition\_#\_Reset** *bool*: Set back to equivalent of 0 when completed.
 

--- a/NPCAsset/Conditions.md
+++ b/NPCAsset/Conditions.md
@@ -1,7 +1,7 @@
 Conditions
 ==========
 
-Conditions can be held by NPC assets, interactable objects, and item blueprints.
+Conditions can be held by NPC assets, interactable objects, and item blueprints. The specific property prefix may differ between asset types.
 
 **Conditions** *byte*: Total number of conditions.
 

--- a/NPCAsset/Rewards.md
+++ b/NPCAsset/Rewards.md
@@ -1,7 +1,7 @@
 Rewards
 =======
 
-Rewards can be granted by NPC assets, interactable objects, and item blueprints.
+Rewards can be granted by NPC assets, interactable objects, and item blueprints. The specific property prefix may differ between asset types.
 
 **Rewards** *byte*: Total number of rewards.
 

--- a/NPCAsset/Rewards.md
+++ b/NPCAsset/Rewards.md
@@ -3,9 +3,9 @@ Rewards
 
 Rewards can be granted by NPC assets, interactable objects, and item blueprints.
 
-**Rewards**: Total number of rewards.
+**Rewards** *byte*: Total number of rewards.
 
-**Reward\_#\_Type** *enum*
+**Reward\_#\_Type** *enum* (`Flag_Bool`, `Flag_Math`, `Flag_Short`, `Flag_Short_Random`, `Achievement`, `Currency`, `Event`, `Experience`, `Item`, `Item_Random`, `Hint`, `Quest`, `Reputation`, `Teleport`, `Vehicle`)
 
 Flags
 -----

--- a/NPCAsset/Rewards.md
+++ b/NPCAsset/Rewards.md
@@ -1,7 +1,7 @@
 Rewards
 =======
 
-Rewards can be granted by NPC assets, interactable objects, and item blueprints. The specific property prefix may differ between asset types.
+Rewards can be granted by NPC assets, interactable objects, and item blueprints. The specific property prefix may differ between asset types. For example, quests may use "Rewards" while consumables use "Quest_Rewards".
 
 **Rewards** *byte*: Total number of rewards.
 


### PR DESCRIPTION
Fixes the data type listed for the **Conditions** and **Rewards** properties. Now, lists them as a *byte*.

Lists out all of the members of the **_Type** enumerated types.

Adds a note to the top of each doc file, which clarifies that the specific names/prefixes of the properties may differ between assets. E.g., **Blueprint_#_Rewards** for blueprints and **Quest_Rewards** for consumables.