### PR TITLE
Documentation for consumable items

### DIFF
--- a/ItemAsset/ConsumeableAsset.md
+++ b/ItemAsset/ConsumeableAsset.md
@@ -1,0 +1,56 @@
+Consumeable Assets
+==================
+
+Consumable items are irreversibly consumed by the player on use, and directly affect a player's stats such as food or health.
+
+This inherits the [WeaponAsset](/ItemAsset/WeaponAsset.md) class.
+
+Consumeable Asset Properties
+============================
+
+**Aid** *bool*: Specified if the item can be used on other players, via the "Secondary" action.
+
+**Bleeding** *bool*: Specified if the item should remove the "Bleeding" status effect. Deprecated in favor of Bleeding_Modifier.
+
+**Bleeding_Modifier** *enum* (`Cut`, `Heal`, `None`): Determines the effect the consumable has in relation to the "Bleeding" status effect.
+
+**Broken** *bool*: Specified if the item should remove the "Broken Bones" status effect. Deprecated in favor of Bones_Modifier.
+
+**Bones_Modifier** *enum* (`Break`, `Heal`, `None`): Determines the effect the consumable has in relation to the "Broken Bones" status effect.
+
+**Disinfectant** *byte*: Amount of immunity restored.
+
+**Energy** *byte*: Amount of stamina restored.
+
+**Experience** *int*: Amount of experience added or removed.
+
+**Explosion** *uint16*: ID of the explosion effect to play upon consumption.
+
+**Food** *byte*: Amount of food restored. If the amount of food to restore is larger than the amount of water to restore, then food constrains water.
+
+**Health** *byte*: Amount of health restored.
+
+**Item_Reward_Spawn_ID** *uint16*: ID of the item spawn table to generate an item from upon consuming the consumable. The number of items generated is random, depending on the range defined by Min_Item_Rewards and Max_Item_Rewards.
+
+**Max_Item_Rewards** *int*: Maximum number of items that can be generated from the spawn table specified by Item_Reward_Spawn_ID.
+
+**Min_Item_Rewards** *int*: Minimum number of items that can be generated from the spawn table specified by Item_Reward_Spawn_ID.
+
+**Oxygen** *sbyte*: Amount of oxygen restored or depleted.
+
+**Should_Delete_After_Use** *bool*: Boolean for if the item should be deleted after being consumed. Defaults to true.
+
+**Virus** *byte*: Amount of immunity depleted.
+
+**Vision** *uint*: Length of hallucinations, in seconds. The length does not stack when consuming multiple hallucinogenics. Instead, the timer is reset to the longer value.
+
+**Warmth** *uint*: Amount of warmth added.
+
+**Water** *byte*: Amount of water restored. If the amount of water to restore is less than the amount of food to restore, then water is constrained by food.
+
+Rewards
+-------
+
+Consumables can use quest rewards. A common usage is to create consumables with multiple (but still limited) uses, by placing a new item in the player's inventory after consuming the original. Alternatively, consuming a consumable may be required to complete a quest. Refer to [Rewards.md](/NPCAsset/Rewards.md) for additional documentation.
+
+Blueprint rewards are prefixed with `Quest_`. For example, `Quest_Rewards 1`.

--- a/ItemAsset/FoodAsset.md
+++ b/ItemAsset/FoodAsset.md
@@ -1,0 +1,22 @@
+Food Assets
+===========
+
+Food is irreversibly consumed by the player on use, and directly affect a player's stats such as food or health.
+
+This inherits the [ConsumeableAsset](/ItemAsset/ConsumeableAsset.md) class.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to [GUID](/GUID.md) documentation.
+
+**Type** *enum* (`Food`)
+
+**Useable** *enum* (`Consumeable`)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Food Asset Properties
+---------------------
+
+Food have no unique asset properties. Refer to parent classes for additional properties.

--- a/ItemAsset/MedicalAsset.md
+++ b/ItemAsset/MedicalAsset.md
@@ -1,0 +1,22 @@
+Medical Assets
+==============
+
+Medicine is irreversibly consumed by the player on use, and directly affect a player's stats such as health or immunity.
+
+This inherits the [ConsumeableAsset](/ItemAsset/ConsumeableAsset.md) class.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to [GUID](/GUID.md) documentation.
+
+**Type** *enum* (`Medical`)
+
+**Useable** *enum* (`Consumeable`)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Food Asset Properties
+---------------------
+
+Medicine have no unique asset properties. Refer to parent classes for additional properties.

--- a/ItemAsset/MedicalAsset.md
+++ b/ItemAsset/MedicalAsset.md
@@ -16,7 +16,7 @@ Item Asset Properties
 
 **ID** *uint16*: Must be a unique identifier.
 
-Food Asset Properties
----------------------
+Medical Asset Properties
+------------------------
 
 Medicine have no unique asset properties. Refer to parent classes for additional properties.

--- a/ItemAsset/WaterAsset.md
+++ b/ItemAsset/WaterAsset.md
@@ -16,7 +16,7 @@ Item Asset Properties
 
 **ID** *uint16*: Must be a unique identifier.
 
-Food Asset Properties
----------------------
+Water Asset Properties
+----------------------
 
 Drinks have no unique asset properties. Refer to parent classes for additional properties.

--- a/ItemAsset/WaterAsset.md
+++ b/ItemAsset/WaterAsset.md
@@ -1,0 +1,22 @@
+Water Assets
+============
+
+Drinks are irreversibly consumed by the player on use, and directly affect a player's stats such as water or stamina.
+
+This inherits the [ConsumeableAsset](/ItemAsset/ConsumeableAsset.md) class.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to [GUID](/GUID.md) documentation.
+
+**Type** *enum* (`Water`)
+
+**Useable** *enum* (`Consumeable`)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Food Asset Properties
+---------------------
+
+Drinks have no unique asset properties. Refer to parent classes for additional properties.

--- a/ItemAsset/WeaponAsset.md
+++ b/ItemAsset/WeaponAsset.md
@@ -1,0 +1,93 @@
+Weapon Assets
+=============
+
+Weapon assets function as a source of damage. The fucntional implementation of properties may differ slightly between assets.
+
+This inherits the [ItemAsset](/ItemAsset/README.md) class.
+
+Weapon Asset Properties
+=======================
+
+**Allow_Flesh_Fx** *bool*: Boolean for if special effects should occur when damaging flesh. Defaults to true.
+
+**Durability** *float*: Probability of quality loss upon the weapon being used, as a decimal.
+
+**Range** *float*: The maximum distance in meters before damage is no longer possible. For ballistic ranged weapons, this is the maximum distance a projectile may travel. For melee weapons, this is the maximum swinging distance. For explosive weapons, this is the radius of the explosion.
+
+**Wear** *byte*: Increment to degrade quality by. Defaults to 1.
+
+Player Damage
+-------------
+
+**Bypass_Allowed_To_Damage_Player** *bool*: Boolean for if the weapon should bypass the requirements for being allowed to damage other players. Typically, a weapon cannot damage another player if the server is set to PvE, or if the target player is a part of the same group and friendly fire is disabled. Defaults to false.
+
+**Player_Damage** *float*: Amount of damage that should be dealt to player entities, prior to modifiers such as limb multipliers.
+
+**Player_Leg_Multiplier** *float*: Multiplier on damage targeted against a player's legs. Limb multipliers are not utilized by explosive weapons.
+
+**Player_Arm_Multiplier** *float*: Multiplier on damage targeted against a player's arms. Limb multipliers are not utilized by explosive weapons.
+
+**Player_Spine_Multiplier** *float*: Multiplier on damage targeted against a player's torso. Limb multipliers are not utilized by explosive weapons.
+
+**Player_Skull_Multiplier** *float*: Multiplier on damage targeted against a player's head. Limb multipliers are not utilized by explosive weapons.
+
+**Player_Damage_Bleeding** *enum* (`Always`, `Default`, `Heal`, `Never`): Determines the effect the weapon has in relation to the "Bleeding" status effect. Defaults to "Default" enumerator.
+
+**Player_Damage_Bones** *enum* (`Always`, `Heal`, `None`): Determines the effect the weapon has in relation to the "Broken Bones" status effect. Defaults to the "None" enumerator.
+
+**Player_Damage_Food**: Amount of degradation dealt to a targeted player's food.
+
+**Player_Damage_Water**: Amount of degradation dealt to a targeted player's water.
+
+**Player_Damage_Virus**: Amount of degradation dealt to a targeted player's immunity.
+
+**Player_Damage_Hallucination**: Length of hallucinations inflicted onto a targeted player, in seconds.
+
+Zombie Damage
+-------------
+
+**Zombie_Damage** *float*: Amount of damage that should be dealt to zombie entities, prior to modifiers such as limb multipliers.
+
+**Zombie_Leg_Multiplier** *float*: Multiplier on damage targeted against a zombie's legs. Limb multipliers are not utilized by explosive weapons.
+
+**Zombie_Arm_Multiplier** *float*: Multiplier on damage targeted against a zombie's arms. Limb multipliers are not utilized by explosive weapons.
+
+**Zombie_Spine_Multiplier** *float*: Multiplier on damage targeted against a zombie's torso. Limb multipliers are not utilized by explosive weapons.
+
+**Zombie_Skull_Multiplier** *float*: Multiplier on damage targeted against a zombie's head. Limb multipliers are not utilized by explosive weapons.
+
+**Stun_Zombie_Always** *bool*: Specified if a zombie should always be stunned when targeted by the weapon.
+
+**Stun_Zombie_Never** *bool*: Specified if a zombie should never be stunned when targeted by the weapon.
+
+Animal Damage
+-------------
+
+**Animal_Damage** *float*: Amount of damage that should be dealt to animal entities, prior to modifiers such as limb multipliers.
+
+**Animal_Leg_Multiplier** *float*: Multiplier on damage targeted against a animal's limbs. Limb multipliers are not utilized by explosive weapons.
+
+**Animal_Spine_Multiplier** *float*: Multiplier on damage targeted against a animal's torso. Limb multipliers are not utilized by explosive weapons.
+
+**Animal_Skull_Multiplier** *float*: Multiplier on damage targeted against a animal's head. Limb multipliers are not utilized by explosive weapons.
+
+Construct Damage
+----------------
+
+**BladeID** *byte*: Weapon can damage any resources that have a matching BladeID. Deprecated in favor of BladeIDs and BladeID_#.
+
+**BladeIDs** *int*: Total number of unique BladeID_# values.
+
+**BladeID_#** *byte*: Weapon can damage any resources that have a matching BladeID_# value.
+
+**Barricade_Damage** *float*: Amount of damage that should be dealt to barricades, prior to modifiers.
+
+**Structure_Damage** *float*: Amount of damage that should be dealt to structures, prior to modifiers.
+
+**Vehicle_Damage** *float*: Amount of damage that should be dealt to vehicles, prior to modifiers.
+
+**Resource_Damage** *float*: Amount of damage that should be dealt to resources, prior to modifiers.
+
+**Object_Damage** *float*: Amount of damage that should be dealt to objects, prior to modifiers. Defaults to the value used by Resource_Damage.
+
+**Invulnerable** *bool*: Specified if damage should affect structures, barricades, and vehicles that are considered invulnerable to low-power weaponry. Not applicable to explosive weapons, which will always ignore invulnerability.


### PR DESCRIPTION
Documentation for consumables.

Regarding the **WeaponAsset.md** file specifically... Is there a better term for grouping barricades, structures, vehicles, resources, and objects together? Maybe ***world***, ***environmental***, or ***props***? (The doc currently uses ***constructs***.)

I've traditionally used terms such as *constructs*, but this is technically already used by structures. I've also used *non-entities*, but I'm not sure if that'd actually be accurate. For comparison, I typically group animal/player/zombie as *creatures*.