### PR TITLE
3.22.4.0 removed support for *.content files

### DIFF
--- a/AssetBundles.md
+++ b/AssetBundles.md
@@ -78,7 +78,7 @@ When beginning development of 3.0, it was key to support runtime loading of cust
 
 ## Content Bundles (*.content) *DEPRECATED*
 
-This format was used by terrain, material palettes and radio songs. After the 3.21.15.0 update on 2021-04-23 these can all use master bundles instead. Old references from these assets will continue to function, but new references should use a master bundle name and relative path for the "Name" and "Path" properties.
+This format was used by terrain, material palettes, and radio songs. After the April 23, 2021 patch (version 3.21.15.0) these assets can all use master bundles instead. As of the February 25, 2022 patch (version 3.22.4.0) any remaining support for content bundles has been removed. New references should use a master bundle name and relative path for the "Name" and "Path" properties.
 
 ### Tool Usage:
 


### PR DESCRIPTION
Could probably go harder with trimming down the section, but at a minimum I feel it's at least important to note the official removal of support.

Maybe cut the section out entirely, and have a section for deprecated features? (Technically, there's a slim chance that some people might be creating mods specifically for the older builds of the game that are available from the beta branches tab. Aside from that – some very minor historical value, although people could just look up an older commit if they really wanted to know this information.)