### PR TITLE
Flags (bool → flag)

### DIFF
--- a/EffectAsset.md
+++ b/EffectAsset.md
@@ -18,15 +18,15 @@ General data
 
 **Gore** *bool*: Effect is hidden when gore is disabled.
 
-**Static** *bool*: Disable randomized audio pitch change.
+**Static** *flag*: Disable randomized audio pitch change.
 
 **Randomize_Rotation** *bool*: Rolls the effect around the hit axis. Defaults to true.
 
-**Spawn_On_Dedicated_Server** *bool*: Spawn effect on server.
+**Spawn_On_Dedicated_Server** *flag*: Spawn effect on server.
 
 **Relevant_Distance** *float*: How far away players can be before an asset effect should not be sent to them, measured in meters. Players within this radius will be sent the effect in multiplayer.
 
-**Preload** *bool*: Total number of the effect to pre-instantiate in the effect pool to reduce hitching when first used.
+**Preload** *byte*: Total number of the effect to pre-instantiate in the effect pool to reduce hitching when first used.
 
 Splatters
 ---------
@@ -39,8 +39,8 @@ Splatters
 
 **Splatter_Lifetime_Spread** *float*: Variation on the duration of each individual splatter after effect spawn. A random value is chosen between the specified spread value, and the negative of that spread value. Default is 1 second.
 
-**Splatter_Liquid** *bool*: Splatters are visible regardless of effect graphics settings being disabled, and slightly changes the direction of each splatter.
+**Splatter_Liquid** *flag*: Splatters are visible regardless of effect graphics settings being disabled, and slightly changes the direction of each splatter.
 
 **Splatter_Temperature** *enum* (`Acid`, `Burning`, `Warm`): Temperature status effect caused when standing in the effect.
 
-**Splatter_Preload** *bool*: Total number of the splatter effects to pre-instantiate in the effect pool to reduce hitching when first used.
+**Splatter_Preload** *byte*: Total number of the splatter effects to pre-instantiate in the effect pool to reduce hitching when first used.

--- a/ItemAsset/Actions.md
+++ b/ItemAsset/Actions.md
@@ -13,7 +13,7 @@ Add additional context actions; the system currently supports [blueprint](Bluepr
 
 **Action\_#\_Blueprint\_#\_Index** *int*: Index of the blueprint that action should perform.
 
-**Action\_#\_Blueprint\_#\_Link** *bool*: Action should redirect to the associated blueprint listing, rather than immediately craft the item.
+**Action\_#\_Blueprint\_#\_Link** *flag*: Action should redirect to the associated blueprint listing, rather than immediately craft the item.
 
 Button Properties
 -----------------

--- a/ItemAsset/BarrelAsset.md
+++ b/ItemAsset/BarrelAsset.md
@@ -19,12 +19,12 @@ Barrel Asset Properties
 
 **Ballistic_Drop** *float*: Multiplier on ballistic drop. Defaults to 1.
 
-**Braked** *bool*: Specified if a muzzle flash should be hidden.
+**Braked** *flag*: Specified if a muzzle flash should be hidden.
 
 **Durability** *byte*: Amount of quality lost after each firing of the ranged weapon. When this value is greater than 0, the item always has a visible item quality shown. Defaults to 0.
 
 **Gunshot_Rolloff_Distance_Multiplier** *float*: Multiplier on gunshot rolloff distance. Defaults to 0.5 if Silenced, otherwise to 1.
 
-**Silenced** *bool*: Specified if alerts should not be generated.
+**Silenced** *flag*: Specified if alerts should not be generated.
 
 **Volume** *float*: Multiplier on gunfire sound volume.

--- a/ItemAsset/Blueprints.md
+++ b/ItemAsset/Blueprints.md
@@ -11,13 +11,13 @@ Blueprints
 
 **Blueprint\_#\_Supply\_#\_Amount** *int*: Quantity of the unique supply required.
 
-**Blueprint\_#\_Supply\_#\_Critical** *bool*: The unique supply is a prerequisite to showing the blueprint listing.
+**Blueprint\_#\_Supply\_#\_Critical** *flag*: The unique supply is a prerequisite to showing the blueprint listing.
 
-**Blueprint\_#\_State\_Transfer** *bool*: Transfer current state of supplies to product.
+**Blueprint\_#\_State\_Transfer** *flag*: Transfer current state of supplies to product.
 
 **Blueprint\_#\_Tool** *int16*: ID of the unique non-consumed tool required.
 
-**Blueprint\_#\_Tool_Critical** *bool*: The unique non-consumed tool is a prerequisite to showing the blueprint listing.
+**Blueprint\_#\_Tool_Critical** *flag*: The unique non-consumed tool is a prerequisite to showing the blueprint listing.
 
 **Blueprint\_#\_Level** *int*: Skill level required.
 

--- a/ItemAsset/CaliberAsset.md
+++ b/ItemAsset/CaliberAsset.md
@@ -16,7 +16,7 @@ Caliber Asset Properties
 
 **Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
 
-**Paintable** *bool*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
+**Paintable** *flag*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
 
 **Recoil_X** *float*: Multiplier on horizontal recoil.
 

--- a/ItemAsset/ConsumeableAsset.md
+++ b/ItemAsset/ConsumeableAsset.md
@@ -8,13 +8,13 @@ This inherits the [WeaponAsset](/ItemAsset/WeaponAsset.md) class.
 Consumeable Asset Properties
 ============================
 
-**Aid** *bool*: Specified if the item can be used on other players, via the "Secondary" action.
+**Aid** *flag*: Specified if the item can be used on other players, via the "Secondary" action.
 
-**Bleeding** *bool*: Specified if the item should remove the "Bleeding" status effect. Deprecated in favor of Bleeding_Modifier.
+**Bleeding** *flag*: Specified if the item should remove the "Bleeding" status effect. Deprecated in favor of Bleeding_Modifier.
 
 **Bleeding_Modifier** *enum* (`Cut`, `Heal`, `None`): Determines the effect the consumable has in relation to the "Bleeding" status effect.
 
-**Broken** *bool*: Specified if the item should remove the "Broken Bones" status effect. Deprecated in favor of Bones_Modifier.
+**Broken** *flag*: Specified if the item should remove the "Broken Bones" status effect. Deprecated in favor of Bones_Modifier.
 
 **Bones_Modifier** *enum* (`Break`, `Heal`, `None`): Determines the effect the consumable has in relation to the "Broken Bones" status effect.
 

--- a/ItemAsset/GripAsset.md
+++ b/ItemAsset/GripAsset.md
@@ -17,4 +17,4 @@ Item Asset Properties
 Grip Asset Properties
 ---------------------
 
-**Bipod** *bool*: Specified if effects should only take place while prone.
+**Bipod** *flag*: Specified if effects should only take place while prone.

--- a/ItemAsset/MagazineAsset.md
+++ b/ItemAsset/MagazineAsset.md
@@ -29,7 +29,7 @@ Magazine Asset Properties
 
 **Stuck** *byte*: Amount of quality to lose when hit. When this value is greater than 0, fired projectiles can be picked back up until their quality reaches 0. Defaults to 0.
 
-**Explosive** *bool*: Specified if it should cause an area-of-effect explosion.
+**Explosive** *flag*: Specified if it should cause an area-of-effect explosion.
 
 **Range** *float*: Radius of the area-of-effect explosion.
 
@@ -59,6 +59,6 @@ Magazine Asset Properties
 
 **Impact** *uint16*: Impact effect ID. Defaults to 0.
 
-**Delete_Empty** *bool*: Specified if the magazine attachment should be deleted when it is fully depleted.
+**Delete_Empty** *flag*: Specified if the magazine attachment should be deleted when it is fully depleted.
 
 **Should_Fill_After_Detach** *bool*: Ammunition should be fully refilled after the magazine attachment is detached from a ranged weapon. Defaults to false.

--- a/ItemAsset/MapAsset.md
+++ b/ItemAsset/MapAsset.md
@@ -17,8 +17,8 @@ Item Asset Properties
 Map Asset Properties
 --------------------
 
-**Enables_Map**: Provides access to a satellite map display.
+**Enables_Map** *flag*: Provides access to a satellite map display.
 
-**Enables_Chart**: Provides access to a chart map display.
+**Enables_Chart** *flag*: Provides access to a chart map display.
 
-**Enables_Compass**: Provides a compass HUD, and the ability to set waypoints on the map display.
+**Enables_Compass** *flag*: Provides a compass HUD, and the ability to set visible waypoints on the map display.

--- a/ItemAsset/SightAsset.md
+++ b/ItemAsset/SightAsset.md
@@ -17,7 +17,7 @@ Item Asset Properties
 Sight Asset Properties
 ----------------------
 
-**Holographic** *bool*: Specified if sight is holographic.
+**Holographic** *flag*: Specified if sight is holographic.
 
 **Nightvision_Color_B** *uint8*: The blue color component of an RGBA color, represented as a byte. Default value for Civilian is equivalent to 102. Default value for Military is 20. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
 

--- a/ItemAsset/TacticalAsset.md
+++ b/ItemAsset/TacticalAsset.md
@@ -17,10 +17,10 @@ Item Asset Properties
 Tactical Asset Properties
 -------------------------
 
-**Laser** *bool*: Provides a toggleable laser.
+**Laser** *flag*: Provides a toggleable laser.
 
-**Light** *bool*: Provides a toggleable flashlight.
+**Light** *flag*: Provides a toggleable flashlight.
 
-**Melee** *bool*: Provides the ability to perform a melee attack.
+**Melee** *flag*: Provides the ability to perform a melee attack.
 
-**Rangefinder** *bool*: Provides a toggleable rangefinder.
+**Rangefinder** *flag*: Provides a toggleable rangefinder.

--- a/ItemAsset/WeaponAsset.md
+++ b/ItemAsset/WeaponAsset.md
@@ -56,9 +56,9 @@ Zombie Damage
 
 **Zombie_Skull_Multiplier** *float*: Multiplier on damage targeted against a zombie's head. Limb multipliers are not utilized by explosive weapons.
 
-**Stun_Zombie_Always** *bool*: Specified if a zombie should always be stunned when targeted by the weapon.
+**Stun_Zombie_Always** *flag*: Specified if a zombie should always be stunned when targeted by the weapon.
 
-**Stun_Zombie_Never** *bool*: Specified if a zombie should never be stunned when targeted by the weapon.
+**Stun_Zombie_Never** *flag*: Specified if a zombie should never be stunned when targeted by the weapon.
 
 Animal Damage
 -------------
@@ -90,4 +90,4 @@ Construct Damage
 
 **Object_Damage** *float*: Amount of damage that should be dealt to objects, prior to modifiers. Defaults to the value used by Resource_Damage.
 
-**Invulnerable** *bool*: Specified if damage should affect structures, barricades, and vehicles that are considered invulnerable to low-power weaponry. Not applicable to explosive weapons, which will always ignore invulnerability.
+**Invulnerable** *flag*: Specified if damage should affect structures, barricades, and vehicles that are considered invulnerable to low-power weaponry. Not applicable to explosive weapons, which will always ignore invulnerability.

--- a/NPCAsset/Characters.md
+++ b/NPCAsset/Characters.md
@@ -28,7 +28,7 @@ Clothing
 
 NPC characters can have event-specific outfits, which will only appear during the assigned seasonal event.
 
-**Has_Halloween_Outfit** *bool*: Event-specific clothing should be worn during the Halloween event.
+**Has_Halloween_Outfit** *flag*: Specified if event-specific clothing should be worn during the Halloween event.
 
 **Halloween_Shirt** *uint16*: ID of shirt to wear during the Halloween event.
 
@@ -44,7 +44,7 @@ NPC characters can have event-specific outfits, which will only appear during th
 
 **Halloween_Glasses** *uint16*: ID of glasses to wear during the Halloween event.
 
-**Has_Christmas_Outfit** *bool*: Event-specific clothing should be worn during the Festive event.
+**Has_Christmas_Outfit** *flag*: Specified if event-specific clothing should be worn during the Festive event.
 
 **Christmas_Shirt** *uint16*: ID of shirt to wear.
 
@@ -75,7 +75,7 @@ While in the Appearance menu in-game, modders can press Page Down to copy the pl
 
 **Color_Hair** *hex triplet*: Six-digit hexadecimal number representing RGB color.
 
-**Backward** *bool*: Character is left-handed.
+**Backward** *flag*: Specified if character is left-handed.
 
 Pose
 ----

--- a/NPCAsset/Conditions.md
+++ b/NPCAsset/Conditions.md
@@ -7,7 +7,7 @@ Conditions can be held by NPC assets, interactable objects, and item blueprints.
 
 **Condition\_#\_Type** *enum* (`Compare_Flags`, `Flag_Bool`, `Flag_Short`, `Currency`, `Experience`, `Item`, `Kills_Animal`, `Kills_Horde`, `Kills_Object`, `Kills_Player`, `Kills_Tree`, `Kills_Resource`, `Player_Life_Food`, `Player_Life_Health`, `Player_Life_Virus`, `Player_Life_Water`, `Quest`, `Reputation`, `Skillset`, `Holiday`, `Time_Of_Day`, `Weather_Blend_Alpha`, `Weather_Status`)
 
-**Condition\_#\_Reset** *bool*: Set back to equivalent of 0 when completed.
+**Condition\_#\_Reset** *flag*: Set back to equivalent of 0 when completed.
 
 **Condition\_#\_Logic** *enum* (`Less_Than`, `Less_Than_Or_Equal_To`, `Equal`, `Not_Equal`, `Greater_Than_Or_Equal_To`, `Greater_Than`): Compare current state to target state.
 
@@ -38,7 +38,7 @@ Boolean flag condition.
 
 **Condition\_#\_Value** *bool*: Target value, as a boolean.
 
-**Condition\_#\_Allow_Unset** *bool*: Pass condition if player does not have the flag yet.
+**Condition\_#\_Allow_Unset** *flag*: Pass condition if player does not have the flag yet.
 
 ### Flag_Short
 
@@ -50,7 +50,7 @@ Short flag condition.
 
 **Condition\_#\_Value** *int*: Target value for the flag, as a 16-bit signed integer.
 
-**Condition\_#\_Allow\_Unset** *bool*: Pass condition if player does not have the flag yet.
+**Condition\_#\_Allow\_Unset** *flag*: Pass condition if player does not have the flag yet.
 
 Player
 ------
@@ -147,7 +147,7 @@ Refer to [Currency](/Currency.md) documentation.
 
 **Condition\_#\_MinRadius** *float*: Zombies must be killed at least this many meters away from the player.
 
-**Condition\_#\_Spawn** *bool*: The zombie type should be forcefully generated upon entering the area, which will then be deleted upon leaving the area.
+**Condition\_#\_Spawn** *flag*: Specified if the zombie type should be forcefully generated upon entering the area, which will then be deleted upon leaving the area.
 
 ### Player_Life_Food
 
@@ -181,7 +181,7 @@ Refer to [Currency](/Currency.md) documentation.
 
 **Condition\_#\_Status** *enum* (`Active`, `Completed`, `Ready`): Current state of the quest.
 
-**Condition\_#\_Ignore\_NPC** *bool*: Player does not need to be talking to an NPC within 20 meters for the quest to be completable and turned in.
+**Condition\_#\_Ignore\_NPC** *flag*: Player does not need to be talking to an NPC within 20 meters for the quest to be completable and turned in.
 
 ### Reputation
 
@@ -208,7 +208,7 @@ World
 
 **Condition\_#\_Type** *enum* (`Time_Of_Day`)
 
-**Condition\_#\_Second**: Second of a 24-hour clock (military time) to compare against, where 43,200 is noon and 86,400 is a full day.
+**Condition\_#\_Second** *int*: Second of a 24-hour clock (military time) to compare against, where 43,200 is noon and 86,400 is a full day.
 
 ### Weather_Blend_Alpha
 

--- a/NPCAsset/Rewards.md
+++ b/NPCAsset/Rewards.md
@@ -111,7 +111,7 @@ Refer to [Currency](/Currency.md) documentation.
 
 **Reward\_#\_Amount** *int*: Amount of item to reward.
 
-**Reward\_#\_Auto\_Equip** *bool*: Item should be automatically equipped by the player.
+**Reward\_#\_Auto\_Equip** *flag*: Item should be automatically equipped by the player.
 
 ### Hint
 

--- a/NPCAsset/Vendors.md
+++ b/NPCAsset/Vendors.md
@@ -36,7 +36,7 @@ Properties pertaining to items or vehicles that the vendor is willing to sell to
 Other Properties
 ----------------
 
-**Disable_Sorting** *bool*: Disable vendor sorting.
+**Disable_Sorting** *flag*: Disable vendor sorting.
 
 **Currency** *string*: GUID of [currency asset](/Currency.md) to use as currency instead of experience points.
 

--- a/SpawnAsset.md
+++ b/SpawnAsset.md
@@ -18,7 +18,7 @@ Roots are the spawners that your spawn table will attach itself to. This is usef
 
 **Root\_#\_Spawn\_ID** *uint16*:  ID of parent spawn table.
 
-**Root\_#\_Override** *bool*: Zeroes the weight of default spawns in the parent spawn table. Useful for mods intended to replace official content, such as with total conversions.
+**Root\_#\_Override** *flag*: Zeroes the weight of default spawns in the parent spawn table. Useful for mods intended to replace official content, such as with total conversions.
 
 **Root\_#\_Weight** *int*: Weight of this table in the parent spawn table.
 


### PR DESCRIPTION
Changes the listed data type for many properties from _bool_ to _flag_. Should be less confusing. In some cases, also modifies the description of the property to be slightly more concise.

Includes some misc. corrections to other non-flag properties, and adds data types to properties missing one.