### PR TITLE
Pro flag and IsPro boolean?

### DIFF
--- a/ItemAsset/README.md
+++ b/ItemAsset/README.md
@@ -39,6 +39,8 @@ Economy Properties
 
 **Size2_Z** *float*: Orthogonal camera size for economy icons. Defaults to -1.
 
+**Pro** *flag*: Specified if this is an economy item.
+
 **Is_Pro** *bool*: Set as an economy item. Defaults to false.
 
 **Shared\_Skin\_Lookup\_ID** *uint16*: Share skins with another item. Defaults to item ID.


### PR DESCRIPTION
This PR adds the `Pro` flag property to the documentation.

----

I have some confusion regarding what I'm looking at in regards to ItemAssets. There appears to be both a "**Is_Pro**" _boolean_ property, and a "**Pro**" _flag_ property.

Item .dat files only ever reference the "Pro" flag property. What is the other property? Is it relevant to have on the docs?