### PR TITLE
Remove Is_Pro boolean

### DIFF
--- a/ItemAsset/README.md
+++ b/ItemAsset/README.md
@@ -41,8 +41,6 @@ Economy Properties
 
 **Pro** *flag*: Specified if this is an economy item.
 
-**Is_Pro** *bool*: Set as an economy item. Defaults to false.
-
 **Shared\_Skin\_Lookup\_ID** *uint16*: Share skins with another item. Defaults to item ID.
 
 Container Properties


### PR DESCRIPTION
This PR removes Is_Pro documentation, based on additional information provided from #157. 

Is_Pro is from a partial rewrite -- safe to exclude from docs.