### PR TITLE
Optic assets + scope zoom

### DIFF
--- a/ItemAsset/OpticType.md
+++ b/ItemAsset/OpticType.md
@@ -1,0 +1,22 @@
+Optic Assets
+============
+
+Optics can modify a player's view.
+
+This inherits the [ItemAsset](/ItemAsset/README.md) class.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to [GUID](/GUID.md) documentation.
+
+**Type** *enum* (`Optic`)
+
+**Useable** *enum* (`Optic`)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Sight Asset Properties
+----------------------
+
+**Zoom** *float*: Multiplicative amount of zoom. Defaults to 1.

--- a/ItemAsset/SightAsset.md
+++ b/ItemAsset/SightAsset.md
@@ -29,4 +29,4 @@ Sight Asset Properties
 
 **Vision** *enum* (`None`, `Military`, `Civilian`, `Headlamp`): Type of unique lighting vision effect to use. Defaults to None. Use the Military enumerator when intending to assign a custom nightvision color via the color component properties.
 
-**Zoom** *float*: Multiplicative amount of zoom. Defaults to 1.
+**Zoom** *float*: Multiplicative amount of zoom. Should be set to a value greater than 1. Defaults to 1.


### PR DESCRIPTION
Documentation for optic assets. Includes an update to SightAsset.md as well, to clarify that zoom should be set to a value greater than 1.

Technically, the "Zoom" data type for optics isn't a float _right now_, but _it will be_ as of the next mainline game update.