### PR TITLE
Further clarify curation guidelines

### DIFF
--- a/CuratedMaps.md
+++ b/CuratedMaps.md
@@ -1,10 +1,18 @@
 Curated Maps
 ============
 
-Overview
---------
+Community-created maps that are officially linked from the game are considered **Curated Maps**. They help players find high-quality new experiences, and keep the game updated with fresh content. Modders can then earn money from their work on their hobby, and get their creations highlighted.
 
-Community-created updates and maps that are officially linked from the game are considered __Curated Maps__. They help players find high-quality new experiences, and keep the game updated with fresh content. Modders can then earn money from their work on their hobby, and get their creations highlighted.
+Eligibility for Curation
+------------------------
+
+Even if a map is of substantial quality, it may not be eligible for curation. When considering eligibility, it is important that the map fits the vanilla style of the game.
+
+Although not every map should be curated, it is important to recognize the amount of effort that modders have put into their projects. Depending on the direction of the project, non-vanilla assets should either be adjusted to fit the vanilla style, or alternatives to curation should be considered instead.
+
+Vanilla-style maps are eligible for curation, whereas non-vanilla maps are eligible to be featured. To help support the creators, both are eligible for revenue sharing cosmetic content in the game's item store e.g. the Candyland map.
+
+It is encouraged to still work on a project even if it is not eligible for curation. Creating a variety of Workshop content creates a valuable portfolio for future curation attempts, and may still benefit from being featured.
 
 Menu Visibility
 ---------------
@@ -31,45 +39,56 @@ Quality Assurance
 
 The primary focus of this article at the time of posting is to begin laying out standards to help ensure top quality between maps. This will be an iterative process, and is open to collaboration and feedback from the community.
 
-__Map Variety__: New maps should feel noticeably different in order to be a candidate for curation. This is a subjective rule, and is covered by factors like interesting progression, new items, new environments, new architecture styles, new buildings, etc.
+**Map Variety**: New maps should feel noticeably different in order to be a candidate for curation. This is a subjective rule, and is covered by factors like interesting progression, new items, new environments, new architecture styles, new buildings, etc.
 
-__Asset Validation__: Running the game with the [-ValidateAssets](ValidateAssets.md) command-line flag should not produce any warnings or errors.
+**Asset Validation**: Running the game with the [-ValidateAssets](ValidateAssets.md) command-line flag should not produce any warnings or errors.
 
-__English Text__: Having an English-speaking member of the mod team is recommended, and [MoltonMontro](mailto:moltonmontro@smartlydressedgames.com) has offered to help with English-related questions. Most importantly in this regard is proper punctuation and grammar: while native English speakers can easily read incorrect punctuation, it is very helpful for non-native readers. Ironically this paragraph probably has some punctuation errors.
+**English Text**: Having an English-speaking member of the mod team is recommended, and [MoltonMontro](mailto:moltonmontro@smartlydressedgames.com) has offered to help with English-related questions. Most importantly in this regard is proper punctuation and grammar: while native English speakers can easily read incorrect punctuation, it is very helpful for non-native readers. Ironically this paragraph probably has some punctuation errors.
 
-__Project Organization__: To prevent unintended assets from being exported into asset bundles, convention is to separate the project files into Sources and MasterBundle directories. Hawaii is split between a directory called "HawaiiMasterBundle" in the project root, and a Sources directory which contains all of the .blend, .mb, .xcf, .psd, .ai, etc files. When exporting the asset bundle this ensures only game files like .fbx and .prefab are included.
+**Project Organization**: To prevent unintended assets from being exported into asset bundles, convention is to separate the project files into Sources and MasterBundle directories. Hawaii is split between a directory called "HawaiiMasterBundle" in the project root, and a Sources directory which contains all of the .blend, .mb, .xcf, .psd, .ai, etc files. When exporting the asset bundle this ensures only game files like .fbx and .prefab are included.
 
-__Asset Duplication__: If multiple objects share identical prefabs, or use vanilla content, asset bundle size can be improved by sharing the same prefabs. For an example of this refer to the vanilla notes using Bundle_Override_Path.
+**Asset Duplication**: If multiple objects share identical prefabs, or use vanilla content, asset bundle size can be improved by sharing the same prefabs. For an example of this refer to the vanilla notes using Bundle_Override_Path.
 
-__Water Reflections__: When using water volumes, only one should have planar reflections enabled. These reflections require rendering the world a second time for each enabled volume, and are some of the most performance expensive effects in the game.
+**Water Reflections**: When using water volumes, only one should have planar reflections enabled. These reflections require rendering the world a second time for each enabled volume, and are some of the most performance expensive effects in the game.
 
-__Overlapping Navmeshes__: No bounds should overlap. Otherwise zombies will appear and disappear unexpectedly in multiplayer.
+**Overlapping Navmeshes**: No bounds should overlap. Otherwise zombies will appear and disappear unexpectedly in multiplayer.
 
-__Visibility Overlay__: The visibility menu in the editor sums the mesh complexity in each region. Ideally there should only be a few red zones.
+**Visibility Overlay**: The visibility menu in the editor sums the mesh complexity in each region. Ideally there should only be a few red zones.
 
-__Item Icons__: Each item should have a proper icon in the inventory. One way to quickly preview the icon is to attach an orthographic camera in Unity, and tune the orthographic size before setting the size in the .dat file.
+**Item Icons**: Each item should have a proper icon in the inventory. One way to quickly preview the icon is to attach an orthographic camera in Unity, and tune the orthographic size before setting the size in the .dat file.
+
+Age Appropriacy
+---------------
+
+All official and curated game content should be what is typically considered family-friendly. As such, there are various restrictions on the type of content that maps seeking curation are allowed implement.
+
+### Profanity
+
+Curated maps should not contain profanity. Objects, story notes, NPC dialogue, quest descriptions, and other such text should be devoid of any profanity. Profanity is anything considered heavy or mild cursing, slurs, or strongly implied.
+
+Occasionally, there may be situations where an alternative to traditional profanity is useful. Nonsense words such as *gosh*, *darn*, *dang*, *drats*, and *heck* are fine to be used. Soft implications—such as a cut-off at the end of dialogue or a lore note—can also be utilized, so long as they are carefully worded to be open to interpretation.
+
+In some situations, it may be better to replace large swaths of text on content such as lore notes with *\[REDACTED]* or *\[UNINTELLIGIBLE]*. Such redactions should be open to interpretation as to what may have been intended, and make sense within the context of the source material. Redactions should not be treated as a method of censoring individual words.
+
+### Drugs, alcohol, and other substances
+
+Explicit depictions of drugs, alcohol, and other substances is not allowed. Although, maps may implement more family-friendly content that is similar in idea, such as berry mixes instead of alcohol. Maps may also choose to implement content that merely has looser, more distant association. Such as vineyards, bottles, kegs, or distilleries.
+
+### Inappropriate content
+
+The depicition of sexual content, or explicit references regarding sexual content, are prohibited in all forms.
 
 Stockpile Preparation
 ---------------------
 
-Each curated map release is usually accompanied by a few cosmetics and skins in the game's item store. Royalties from the sales are shared with the mod team. Even if a project is not eligible for curation, it may be appropriate to have some support-the-creator items in the Stockpile e.g. the Candyland map.
+Each curated map release is usually accompanied by a few cosmetics and skins in the game's item store. Royalties from the sales are shared with the mod team. Even if a project is not eligible for curation, it may be appropriate to have some support-the-creator items in the Stockpile. For example, the [Stockpile bundles](https://store.steampowered.com/itemstore/304930/browse/?searchtext=%22Rootbeer+Ranger+Bundle%22+%22Cottontail+Ops+Bundle%22) created for the [Candyland map](https://steamcommunity.com/sharedfiles/filedetails/?id=1776871385).
 
-__File Sharing__: Ideally the items have been setup for use as clothes in-game, and then exported into a .unitypackage. This package will then be imported into the vanilla project.
+**File Sharing**: Ideally the items have been setup for use as clothes in-game, and then exported into a .unitypackage. This package will then be imported into the vanilla project.
 
-__Curated Workshop Item__: Payment splits are handled by a hidden curated workshop item. Setting this up usually takes a few weeks for new contributors bank and tax information to be processed.
+**Curated Workshop Item**: Payment splits are handled by a hidden curated workshop item. Setting this up usually takes a few weeks for new contributors' bank and tax information to be processed.
 
-__Bundles__: Two or three collections of sets of four to six items.
+**Bundles**: Two or three collections of sets with four to six items each.
 
-__Mystery Boxes__: Fifteen to twenty items that have individual value (not parts of sets like a shirt/pants).
+**Mystery Boxes**: Fifteen to twenty items of rare, epic, or legendary rarity. The box can be themed, but all of the items should be usable individually – avoiding things like a set of matching shirts and pants that cannot be easily mixed with other cosmetic pieces.
 
-
-Eligibility for Curation
-------------------------
-
-Even if a map is of substantial quality, it may not be eligible for curation. When considering eligibility, it is important that the map fits the vanilla style of the game.
-
-Although not every map should be curated, it is important to recognize the amount of effort that modders have put into their projects. Depending on the direction of the project, non-vanilla assets should either be adjusted to fit the vanilla style, or alternatives to curation should be considered instead.
-
-Vanilla-style maps are eligible for curation, whereas non-vanilla maps are eligible to be featured. To help support the creators, both are eligible for revenue sharing cosmetic content in the game's item store e.g. the Candyland map.
-
-It is encouraged to still work on a project even if it is not eligible for curation. Creating a variety of Workshop content creates a valuable portfolio for future curation attempts, and may still benefit from being featured.
+**Playtime Drops**: Ten to twenty items of uncommon rarity. Unlike mystery box contents, it is far more appropriate for playtime drops to have matching sets and simple recolors.


### PR DESCRIPTION
Includes various additions/improvements/tweaks to curation guidelines for clarity.

**Important:** also includes a rough first pass at writing guidelines on age appropriacy (i.e., family friendly content). I've primarily focused on implementing the main points from our discussions, but please review thoroughly.

- **Added guidelines on age appropriacy—that is: profanity, drugs/alcohol, and NSFW content guidelines.**
- Added guidelines regarding playtime drops. **Reasoning:** newer curated maps usually release with free playtime drops, in addition to paid Stockpile bundles. **Note:** technically, precedent would put the range at "ten to thirty items", but that's merely because of Elver2 releasing with 28 items. Unsure if this is an outlier, or if 10-30 is more accurate.
- Clarified the item rarities of mystery box contents, and the rules on theming/sets.
- Included links to Candyland map and their Stockpile bundles. **Reasoning:** visual examples help to show what qualifies for non-curated support of a project.
- Replaced mention of "Community-created updates and maps" with just "Community-created maps". **Reasoning:** curated content updates without a curated map are *very unlikely*.
- Move "Eligibility for Curation" section near the top.
- Minor formatting and wording changes.