### PR TITLE
Reworded to clarify SteamCMD is optional

### DIFF
--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -1,7 +1,7 @@
 Server Hosting
 ==============
 
-All multiplayer servers are hosted using the Unturned Dedicated Server tool. This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD has several benefits, but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
+All multiplayer servers are hosted using the Unturned Dedicated Server tool (sometimes abbreviated to U3DS). This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD has several benefits, but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
 
 __Multiplatform:__
 - [How to Configure Server](#How-to-Configure-Server)
@@ -25,7 +25,11 @@ __Linux:__
 How to Install Server without Steam CMD
 ---------------------------------------
 
-This tool is bundled alongside Unturned, and the server files can be found in the `...Steam\steamapps\common\U3DS directory`. When hosting multiple servers, it is ideal to install and update the server through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
+The Unturned Dedicated Server tool is bundled alongside the Unturned application, but it is considered its own application. The tool is installed and updated independently from the game itself.
+
+When using the default application filters for the Steam Library, tools are not be visible. To install the tool from your Steam Library either search for "Unturned Dedicated Server" via the search filter, or enable the "Tools" application type filter so that tools are visible. Select the "Unturned Dedicated Server" application in your Steam Library, and click the "Install" button.
+
+The tool and the server files are saved to the `...Steam\steamapps\common\U3DS directory`. When hosting multiple servers, it is ideal to install and update the Unturned Dedicated Server tool through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool, instead of managing server tool through your Steam Library.
 
 How to Install SteamCMD on Windows
 ----------------------------------
@@ -60,7 +64,7 @@ How to Install Server using SteamCMD
 
 		quit
 
-4. The server files are now in the ...SteamCMD\steamapps\common\U3DS directory.
+4. The server files are now in the `...SteamCMD\steamapps\common\U3DS` directory.
 
 Continue to: [How to Launch Server on Windows](#How-to-Launch-Server-on-Windows) or [How to Launch Server on Linux](#How-to-Launch-Server-on-Linux)
 
@@ -90,7 +94,7 @@ How to Launch Server on Windows
 
 8. When the command-line interface stops outputting new lines of text, it has finished loading (and finished generating all necessary files). You can safely close the server by executing (typing, and then pressing the "↵ Enter" key on your keyboard) the following command on the command-line interface: `shutdown`
 
-9. The batch script has created a new file directory located in ...\U3DS\Servers, called "MyServer". This directory is where all the savedata and configuration files are kept. Changing the `MyServer` ServerID (from step 5) in the batch script to a different name will allow for keeping savedata separate across multiple servers, and for running multiple servers at once.
+9. The batch script has created a new file directory located in `...\U3DS\Servers`, called "MyServer". This directory is where all the savedata and configuration files are kept. Changing the `MyServer` ServerID (from step 5) in the batch script to a different name will allow for keeping savedata separate across multiple servers, and for running multiple servers at once.
 
 10. (optional) For your server to be visible on the in-game internet server list you will need to set a [Login Token](GameServerLoginTokens.md) and configure [Port Forwarding](PortForwarding.md).
 

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -3,8 +3,6 @@ Server Hosting
 
 All multiplayer servers are hosted using the Unturned Dedicated Server tool. This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD has several benefits, but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
 
-This tool is bundled alongside Unturned, and the server files can be found in the `...Steam\steamapps\common\U3DS directory`. When hosting multiple servers, it is ideal to install and update the server through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
-
 __Multiplatform:__
 - [How to Configure Server](#How-to-Configure-Server)
 - [How to Host Curated Maps](#How-to-Host-Curated-Maps)
@@ -23,6 +21,11 @@ __Windows:__
 __Linux:__
 - [How to Install SteamCMD](#How-to-Install-SteamCMD-on-Linux)
 - [How to Launch Server](#How-to-Launch-Server-on-Linux)
+
+How to Install Server without Steam CMD
+---------------------------------------
+
+This tool is bundled alongside Unturned, and the server files can be found in the `...Steam\steamapps\common\U3DS directory`. When hosting multiple servers, it is ideal to install and update the server through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
 
 How to Install SteamCMD on Windows
 ----------------------------------

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -1,7 +1,7 @@
 Server Hosting
 ==============
 
-All multiplayer servers are hosted using the Unturned Dedicated Server tool (sometimes abbreviated to U3DS). This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD is ideal and has several benefits (such as making it easy to run multiple servers at once, and allowing for both the Unturned game and Unturned Dedicated Server to be running at the same time), but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
+All multiplayer servers are hosted using the Unturned Dedicated Server tool (sometimes abbreviated to U3DS). This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD is ideal and has several benefits, but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
 
 __Multiplatform:__
 - [How to Install Server without SteamCMD](#How-to-Install-Server-without-SteamCMD)
@@ -27,11 +27,17 @@ __Linux:__
 How to Install Server without SteamCMD
 --------------------------------------
 
-The Unturned Dedicated Server tool is bundled alongside the Unturned application, but it is considered its own application. The tool is installed and updated independently from the game itself.
+The Unturned Dedicated Server tool is bundled alongside the Unturned application, but it is considered its own application. The tool is installed and updated independently from the game itself. There are a few issues unique to those installing the Unturned Dedicated Server tool without SteamCMD.
 
-When using the default application filters for the Steam Library, tools are not be visible. To install the tool from your Steam Library either search for "Unturned Dedicated Server" via the search filter, or enable the "Tools" application type filter so that tools are visible. Select the "Unturned Dedicated Server" application in your Steam Library, and click the "Install" button. The server files are saved to the `...Steam\steamapps\common\U3DS directory`.
+1. The Unturned game and the Unturned Dedicated Server tool cannot both be running at the same time.
 
-Navigate to the U3DS directory. The rest of the documentation assumes that the Unturned Dedicated Server tool was downloaded with SteamCMD, rather than through your Steam Library, so some of the documentation may differ slightly.
+2. It is not possible to host multiple servers at once.
+
+3. When using the default application filters for the Steam Library, tools are not be visible.
+
+To install the tool from your Steam Library either search for "Unturned Dedicated Server" via the search filter, or enable the "Tools" application type filter so that tools are visible. Select the "Unturned Dedicated Server" application in your Steam Library, and click the "Install" button. The server files are saved to the `...Steam\steamapps\common\U3DS` directory.
+
+Navigate to the `...Steam\steamapps\common\U3DS` directory. The rest of the documentation assumes that the Unturned Dedicated Server tool was downloaded with SteamCMD, rather than through your Steam Library, so some of the documentation may differ slightly.
 
 Continue to: [How to Launch Server on Windows](#How-to-Launch-Server-on-Windows) or [How to Launch Server on Linux](#How-to-Launch-Server-on-Linux)
 

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -1,7 +1,7 @@
 Server Hosting
 ==============
 
-All multiplayer servers are hosted using the Unturned Dedicated Server tool. This tool is bundled alongside Unturned, and the server files can be found in the ...Steam\steamapps\common\U3DS directory. When hosting multiple servers, it is ideal to install and update the server through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
+All multiplayer servers are hosted using the Unturned Dedicated Server tool. This tool is bundled alongside Unturned, and the server files can be found in the `...Steam\steamapps\common\U3DS directory`. When hosting multiple servers, it is ideal to install and update the server through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
 
 Although SteamCMD is optional when only hosting a single server at a time, this documentation will assume that SteamCMD is being used. If you are not using SteamCMD, some of the documentation may not apply to you.
 

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -1,7 +1,7 @@
 Server Hosting
 ==============
 
-All multiplayer servers are hosted using the Unturned Dedicated Server tool. This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD has several benefits, but is not necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
+All multiplayer servers are hosted using the Unturned Dedicated Server tool. This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD has several benefits, but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
 
 This tool is bundled alongside Unturned, and the server files can be found in the `...Steam\steamapps\common\U3DS directory`. When hosting multiple servers, it is ideal to install and update the server through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
 
@@ -43,7 +43,7 @@ Installation on Linux varies by distribution and your admin preferences, so refe
 Continue to: [How to Install Server using SteamCMD](#How-to-Install-Server-using-SteamCMD)
 
 How to Install Server using SteamCMD
--------------------------------------------------------
+------------------------------------
 
 1. Login to Steam anonymously:
 

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -171,8 +171,7 @@ To include a Workshop file on your server:
 
 4. During startup the files will be updated, and any dependencies detected. Players will have the files downloaded while connecting to the server.
 
-How to Host Curated Maps
-------------------------
+### How to Host Curated Maps
 
 Curated maps are available as workshop items, so are configured in the `WorkshopDownloadConfig.json` file. During startup the Map command searches installed workshop items for a matching name.
 

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -1,9 +1,11 @@
 Server Hosting
 ==============
 
-All multiplayer servers are hosted using the Unturned Dedicated Server tool (sometimes abbreviated to U3DS). This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD is ideal and has several benefits, but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
+All multiplayer servers are hosted using the Unturned Dedicated Server tool (sometimes abbreviated to U3DS). This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD is ideal and has several benefits (such as making it easy to run multiple servers at once), but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
 
 __Multiplatform:__
+- [How to Install Server without SteamCMD](#How-to-Install-Server-without-SteamCMD)
+- [How to Install Server using SteamCMD](#How-to-Install-Server-using-SteamCMD)
 - [How to Configure Server](#How-to-Configure-Server)
 - [How to Host Curated Maps](#How-to-Host-Curated-Maps)
 - [How to Host Over Internet](#How-to-Host-Over-Internet)
@@ -22,16 +24,16 @@ __Linux:__
 - [How to Install SteamCMD](#How-to-Install-SteamCMD-on-Linux)
 - [How to Launch Server](#How-to-Launch-Server-on-Linux)
 
-How to Install Server without Steam CMD
----------------------------------------
+How to Install Server without SteamCMD
+--------------------------------------
 
 The Unturned Dedicated Server tool is bundled alongside the Unturned application, but it is considered its own application. The tool is installed and updated independently from the game itself.
 
 When using the default application filters for the Steam Library, tools are not be visible. To install the tool from your Steam Library either search for "Unturned Dedicated Server" via the search filter, or enable the "Tools" application type filter so that tools are visible. Select the "Unturned Dedicated Server" application in your Steam Library, and click the "Install" button. The server files are saved to the `...Steam\steamapps\common\U3DS directory`.
 
-Navigate to the U3DS directory. 
+Navigate to the U3DS directory. The rest of the documentation assumes that the Unturned Dedicated Server tool was downloaded with SteamCMD, rather than through your Steam Library, so some of the documentation may differ slightly.
 
-When hosting multiple servers, it is ideal to manage the Unturned Dedicated Server tool through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool, instead of your Steam Library.
+Continue to: [How to Launch Server on Windows](#How-to-Launch-Server-on-Windows) or [How to Launch Server on Linux](#How-to-Launch-Server-on-Linux)
 
 How to Install SteamCMD on Windows
 ----------------------------------

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -1,7 +1,7 @@
 Server Hosting
 ==============
 
-All multiplayer servers are hosted using the Unturned Dedicated Server tool. This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
+All multiplayer servers are hosted using the Unturned Dedicated Server tool. This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD has several benefits, but is not necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
 
 This tool is bundled alongside Unturned, and the server files can be found in the `...Steam\steamapps\common\U3DS directory`. When hosting multiple servers, it is ideal to install and update the server through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
 

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -27,13 +27,13 @@ __Linux:__
 How to Install Server without SteamCMD
 --------------------------------------
 
-The Unturned Dedicated Server tool is bundled alongside the Unturned application, but it is considered its own application. The tool is installed and updated independently from the game itself. There are a few issues unique to those installing the Unturned Dedicated Server tool without SteamCMD.
+The Unturned Dedicated Server tool can be installed and updated from your Steam Library. The tool is considered its own application, and is managed separately from the Unturned game itself. There are a few issues unique to those installing the Unturned Dedicated Server tool without SteamCMD, which should be considered before setting up your server.
 
-1. The Unturned game and the Unturned Dedicated Server tool cannot both be running at the same time.
+1. It is not possible to run multiple servers at once.
 
-2. It is not possible to host multiple servers at once.
+2. The tool uses the same executable name as the game, which means that if the game is closed while the server is running then Steam will think the game is still running. This can cause issues such as Steam refusing to launch the game until the server as closed.
 
-3. When using the default application filters for the Steam Library, tools are not be visible.
+With these considerations in mind, it may be preferable to install the Unturned Dedicated Server using SteamCMD instead.For those interested in installing the Unturned Dedicated Server tool without SteamCMD, navigate to your Steam Library. When using the default application filters for the Steam Library, tools (such as for launching dedicated servers) are not be visible in your Library.
 
 To install the tool from your Steam Library either search for "Unturned Dedicated Server" via the search filter, or enable the "Tools" application type filter so that tools are visible. Select the "Unturned Dedicated Server" application in your Steam Library, and click the "Install" button. The server files are saved to the `...Steam\steamapps\common\U3DS` directory.
 

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -1,7 +1,9 @@
 Server Hosting
 ==============
 
-All multiplayer servers are hosted using the Unturned Dedicated Server tool, which is installed and updated through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
+All multiplayer servers are hosted using the Unturned Dedicated Server tool. This tool is bundled alongside Unturned, and the server files can be found in the ...Steam\steamapps\common\U3DS directory. When hosting multiple servers, it is ideal to install and update the server through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
+
+Although SteamCMD is optional when only hosting a single server at a time, this documentation will assume that SteamCMD is being used. If you are not using SteamCMD, some of the documentation may not apply to you.
 
 __Multiplatform:__
 - [How to Configure Server](#How-to-Configure-Server)

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -29,9 +29,9 @@ The Unturned Dedicated Server tool is bundled alongside the Unturned application
 
 When using the default application filters for the Steam Library, tools are not be visible. To install the tool from your Steam Library either search for "Unturned Dedicated Server" via the search filter, or enable the "Tools" application type filter so that tools are visible. Select the "Unturned Dedicated Server" application in your Steam Library, and click the "Install" button. The server files are saved to the `...Steam\steamapps\common\U3DS directory`.
 
-Navigate to the U3DS directory
+Navigate to the U3DS directory. 
 
-When hosting multiple servers, it is ideal to manage the Unturned Dedicated Server tool through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool, instead of managing server tool through your Steam Library.
+When hosting multiple servers, it is ideal to manage the Unturned Dedicated Server tool through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool, instead of your Steam Library.
 
 How to Install SteamCMD on Windows
 ----------------------------------

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -1,7 +1,7 @@
 Server Hosting
 ==============
 
-All multiplayer servers are hosted using the Unturned Dedicated Server tool (sometimes abbreviated to U3DS). This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD has several benefits, but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
+All multiplayer servers are hosted using the Unturned Dedicated Server tool (sometimes abbreviated to U3DS). This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD is ideal and has several benefits, but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
 
 __Multiplatform:__
 - [How to Configure Server](#How-to-Configure-Server)
@@ -27,9 +27,11 @@ How to Install Server without Steam CMD
 
 The Unturned Dedicated Server tool is bundled alongside the Unturned application, but it is considered its own application. The tool is installed and updated independently from the game itself.
 
-When using the default application filters for the Steam Library, tools are not be visible. To install the tool from your Steam Library either search for "Unturned Dedicated Server" via the search filter, or enable the "Tools" application type filter so that tools are visible. Select the "Unturned Dedicated Server" application in your Steam Library, and click the "Install" button.
+When using the default application filters for the Steam Library, tools are not be visible. To install the tool from your Steam Library either search for "Unturned Dedicated Server" via the search filter, or enable the "Tools" application type filter so that tools are visible. Select the "Unturned Dedicated Server" application in your Steam Library, and click the "Install" button. The server files are saved to the `...Steam\steamapps\common\U3DS directory`.
 
-The tool and the server files are saved to the `...Steam\steamapps\common\U3DS directory`. When hosting multiple servers, it is ideal to install and update the Unturned Dedicated Server tool through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool, instead of managing server tool through your Steam Library.
+Navigate to the U3DS directory
+
+When hosting multiple servers, it is ideal to manage the Unturned Dedicated Server tool through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool, instead of managing server tool through your Steam Library.
 
 How to Install SteamCMD on Windows
 ----------------------------------

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -1,7 +1,7 @@
 Server Hosting
 ==============
 
-All multiplayer servers are hosted using the Unturned Dedicated Server tool (sometimes abbreviated to U3DS). This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD is ideal and has several benefits (such as making it easy to run multiple servers at once), but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
+All multiplayer servers are hosted using the Unturned Dedicated Server tool (sometimes abbreviated to U3DS). This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool. Using SteamCMD is ideal and has several benefits (such as making it easy to run multiple servers at once, and allowing for both the Unturned game and Unturned Dedicated Server to be running at the same time), but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
 
 __Multiplatform:__
 - [How to Install Server without SteamCMD](#How-to-Install-Server-without-SteamCMD)

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -5,8 +5,6 @@ All multiplayer servers are hosted using the Unturned Dedicated Server tool. Thi
 
 This tool is bundled alongside Unturned, and the server files can be found in the `...Steam\steamapps\common\U3DS directory`. When hosting multiple servers, it is ideal to install and update the server through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
 
-Although SteamCMD is optional when only hosting a single server at a time, this documentation will assume that SteamCMD is being used. If you are not using SteamCMD, some of the documentation may not apply to you.
-
 __Multiplatform:__
 - [How to Configure Server](#How-to-Configure-Server)
 - [How to Host Curated Maps](#How-to-Host-Curated-Maps)

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -1,7 +1,9 @@
 Server Hosting
 ==============
 
-All multiplayer servers are hosted using the Unturned Dedicated Server tool. This tool is bundled alongside Unturned, and the server files can be found in the `...Steam\steamapps\common\U3DS directory`. When hosting multiple servers, it is ideal to install and update the server through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
+All multiplayer servers are hosted using the Unturned Dedicated Server tool. This tool can either be installed and updated through your Steam Library, or it can managed through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
+
+This tool is bundled alongside Unturned, and the server files can be found in the `...Steam\steamapps\common\U3DS directory`. When hosting multiple servers, it is ideal to install and update the server through Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool.
 
 Although SteamCMD is optional when only hosting a single server at a time, this documentation will assume that SteamCMD is being used. If you are not using SteamCMD, some of the documentation may not apply to you.
 


### PR DESCRIPTION
A common complaint about server hosting is that people think SteamCMD is **_required_** to host the server. This rewords the intro to clarify that SteamCMD is ideal for multiple servers, but otherwise optional, and that some of the documentation may not apply to those who aren't using SteamCMD.