### PR TITLE
Patch minor fixes

### DIFF
--- a/ItemAsset/GunAsset.md
+++ b/ItemAsset/GunAsset.md
@@ -166,7 +166,7 @@ Defaults to `Player_Damage × 0.1`.
 
 ### Recoil
 
-**Recoil_Aim** *float*: Multiplier on the end value for linear interpolation on recoil when aiming down sights with a scope that has a `Zoom` value greater than 2. Defaults to 1.
+**Recoil_Aim** *float*: Multiplier on the end value for linear interpolation on recoil when aiming down sights, when a sight attachment that has a `Zoom` value greater than 2 is attached. Defaults to 1.
 
 **Recoil_Sprint** *float*: Multiplier on camera recoil while sprinting. Defaults to 1.25. Requires `Can_Aim_During_Sprint true`.
 

--- a/ItemAsset/GunAsset.md
+++ b/ItemAsset/GunAsset.md
@@ -166,7 +166,7 @@ Defaults to `Player_Damage × 0.1`.
 
 ### Recoil
 
-**Recoil_Aim** *float*: Multiplier on the end value for linear interpolation on recoil when aiming down sights, when a sight attachment that has a `Zoom` value greater than 2 is attached. For example, it may be desirable for sniper rifles to use this property say that they have reduced recoil while aiming down a scope. Defaults to 1.
+**Recoil_Aim** *float*: Multiplier on the end value for linear interpolation on recoil when aiming down sights, when a sight attachment that has a `Zoom` value greater than 2 is attached. For example, it may be desirable for sniper rifles to use this property so that they have reduced recoil while aiming down a scope. Defaults to 1.
 
 **Recoil_Sprint** *float*: Multiplier on camera recoil while sprinting. Defaults to 1.25. Requires `Can_Aim_During_Sprint true`.
 

--- a/ItemAsset/GunAsset.md
+++ b/ItemAsset/GunAsset.md
@@ -166,7 +166,7 @@ Defaults to `Player_Damage × 0.1`.
 
 ### Recoil
 
-**Recoil_Aim** *float*: Multiplier on the end value for linear interpolation on recoil when aiming down sights, when a sight attachment that has a `Zoom` value greater than 2 is attached. Defaults to 1.
+**Recoil_Aim** *float*: Multiplier on the end value for linear interpolation on recoil when aiming down sights, when a sight attachment that has a `Zoom` value greater than 2 is attached. For example, it may be desirable for sniper rifles to use this property say that they have reduced recoil while aiming down a scope. Defaults to 1.
 
 **Recoil_Sprint** *float*: Multiplier on camera recoil while sprinting. Defaults to 1.25. Requires `Can_Aim_During_Sprint true`.
 

--- a/ItemAsset/GunAsset.md
+++ b/ItemAsset/GunAsset.md
@@ -25,8 +25,6 @@ Gun Asset Properties
 
 **Can_Aim_During_Sprint** *bool*: If true, the player can sprint while aiming down sights. Defaults to false.
 
-**Durability** *byte*: Amount of quality lost after each firing of the ranged weapon. When this value is greater than 0, the item always has a visible item quality shown. Defaults to 0.
-
 **Gunshot_Rolloff_Distance** *float*: The distance over which the gunshot audio rolls off until it is completely inaudible, in meters. Defaults to 16 when using `Action String`; defaults to 64 when using `Action Rocket`; otherwise, defaults to 512.
 
 **Range_Rangefinder** *float*: Overrides the maximum distance displayed when using the Rangefinder tactical attachment on this ranged weapon. For example, it may be useful to set this property when using `Action Rocket`, as explosive projectiles use `Range` to determine the explosion radius rather than the maximum range of the ranged weapon. Defaults to the value of the `Range` property.

--- a/ItemAsset/GunAsset.md
+++ b/ItemAsset/GunAsset.md
@@ -166,7 +166,7 @@ Defaults to `Player_Damage × 0.1`.
 
 ### Recoil
 
-**Recoil_Aim** *float*: Multiplier on all recoil parameters when aiming down sights. Defaults to 1.
+**Recoil_Aim** *float*: Alpha value (0–1) for linear interpolation on recoil when aiming down sights with a scope that has a `Zoom` value greater than 2. Using a number outside of the aforementioned range results in linear extrapolation instead. Defaults to 1.
 
 **Recoil_Sprint** *float*: Multiplier on camera recoil while sprinting. Defaults to 1.25. Requires `Can_Aim_During_Sprint true`.
 

--- a/ItemAsset/GunAsset.md
+++ b/ItemAsset/GunAsset.md
@@ -166,7 +166,7 @@ Defaults to `Player_Damage × 0.1`.
 
 ### Recoil
 
-**Recoil_Aim** *float*: Alpha value (0–1) for linear interpolation on recoil when aiming down sights with a scope that has a `Zoom` value greater than 2. Using a number outside of the aforementioned range results in linear extrapolation instead. Defaults to 1.
+**Recoil_Aim** *float*: Multiplier on the end value for linear interpolation on recoil when aiming down sights with a scope that has a `Zoom` value greater than 2. Defaults to 1.
 
 **Recoil_Sprint** *float*: Multiplier on camera recoil while sprinting. Defaults to 1.25. Requires `Can_Aim_During_Sprint true`.
 

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -4,8 +4,8 @@ Server Hosting
 All multiplayer servers are hosted using the Unturned Dedicated Server tool (sometimes abbreviated to U3DS). This tool can either be installed and updated using Valve's [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD) tool, or (not recommended) managed through your Steam Library. Using SteamCMD is ideal and has several benefits, but is not strictly necessary. If you are not using SteamCMD, some of the documentation may not apply to you.
 
 __Multiplatform:__
-- [How to Install Server without SteamCMD](#How-to-Install-Server-without-SteamCMD)
 - [How to Install Server using SteamCMD](#How-to-Install-Server-using-SteamCMD)
+- [How to Install Server without SteamCMD](#How-to-Install-Server-without-SteamCMD)
 - [How to Configure Server](#How-to-Configure-Server)
 - [How to Host Curated Maps](#How-to-Host-Curated-Maps)
 - [How to Host Over Internet](#How-to-Host-Over-Internet)


### PR DESCRIPTION
- Removed `Durability` from GunAsset docs, as it's a WeaponAsset property.
- Rearrange order of the server doc's Table of Contents to better match the actual order of section headings.
- Corrected information about `Recoil_Aim` in the gun docs.

For the final bulleted item, note that you've described this as being a reduction with a value 0–1. However: using a value outside greater than 1 works in-game (greater than 1 causes increased recoil), so I'm unsure if this is actually constrained to a value 0–1.