### PR TITLE
Add tunneling instructions to port forwarding

### DIFF
--- a/PortForwarding.md
+++ b/PortForwarding.md
@@ -1,7 +1,7 @@
 Port Forwarding
 ===============
 
-When hosting a server on a home network __port forwarding__ is required in order to direct traffic to the host computer. One way to think of it is that when there are multiple devices (e.g. computers and phones) connected to the LAN, the outside internet does not know which device is the Unturned server. In this case port forwarding specifies which LAN device is the host.
+When hosting a server on a home network __port forwarding__ or __tunneling__ is required in order to direct traffic to the host computer. One way to think of it is that when there are multiple devices (e.g. computers and phones) connected to the LAN, the outside internet does not know which device is the Unturned server. In this case port forwarding specifies which LAN device is the host.
 
 Two pieces of information: the port range and local device address are required prior to port forwarding, and are described in detail below.
 
@@ -42,3 +42,16 @@ In general the steps are along the lines of:
 7. Enable UDP protocol.
 8. Set destination internal IP to the local host address.
 9. Save the new rule.
+
+Tunneling
+---------
+
+It is also possible to use third party services like [playit.gg](https://playit.gg) to tunnel connections to the host computer.
+
+To create a tunnel for unturned:
+1. Create a custom tunnel with port type "TCP+UDP"
+2. For port count, enter "2"
+3. Leave everything else as the default and create the tunnel
+4. Find the assigned port for your tunnel
+5. Update your server's `Commands.dat` file and set `Port <assigned port>` (replace `<assigned port>`)
+6. Connect using your playit address (`something-random.at.ply.gg:<assigned port>`)


### PR DESCRIPTION
Update the port forwarding doc with port forwarding alternative (tunneling) with https://playit.gg.

I'm the creator of https://playit.gg and have found there's quite a few people using us to host Unturned servers. Not sure if this is the right place or if mentioning third party applications is okay.

The service is free and supported by users purchasing custom domains or dedicated IPs.

YouTube videos showing how to do it
(updated) https://www.youtube.com/watch?v=eSk73ELAp1s
(original) https://www.youtube.com/watch?v=Jqmgruvamd4