### PR TITLE
Emphasis on only *CUSTOM* cosmetics being sellable

### DIFF
--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -6,7 +6,9 @@ Servers that violate these rules may be temporarily or permanently banned.
 
 ## Monetization Types
 
-Update 2nd of August 2021: fictitious and deceptive pricing is not allowed. For example, lying that a discount is nearly expired, or pretending the price is discounted when it has never been at full price. We would strongly advise following [Steam's discounting rules](https://partner.steamgames.com/doc/marketing/discounts) to help avoid breaking any real-world laws.
+**October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
+
+**August 2, 2021 update:** Fictitious and deceptive pricing is not allowed. For example, lying that a discount is nearly expired, or pretending the price is discounted when it has never been at full price. We would strongly advise following [Steam's discounting rules](https://partner.steamgames.com/doc/marketing/discounts) to help avoid breaking any real-world laws.
 
 Warnings for breaking the monetization rules first began being sent out on May 28, 2021. The monetization rules have now been in full effect since June 11, 2021.
 
@@ -16,7 +18,7 @@ Examples of allowed monetization:
 - Accepting donations.
 - Selling permanent or monthly subscription access to play on the server(s).
 - Selling ranks, kits, unlocks, benefits, etc. available permanently or for the duration of the monthly subscription. Timers or cooldowns are fine.
-- Selling cosmetics like custom skins, name tags, chat colors, etc. available permanently or for the duration of the monthly subscription.
+- Selling **custom** cosmetics like custom skins, name tags, chat colors, etc. available permanently or for the duration of the monthly subscription.
 - Selling services or commissions, for example a modder taking commissions for new content that gets added to the server for all players.
 
 Examples of banned monetization:
@@ -25,6 +27,7 @@ Examples of banned monetization:
 - Selling experience points.
 - Selling currency.
 - Selling ranks, kits, unlocks, benefits, etc. which stack with themselves as a loophole.
+- Selling copies of **vanilla** cosmetics, such as those available on the Stockpile or Steam Community Market.
 
 ## Monetization Filter
 


### PR DESCRIPTION
It appears that this important context is being lost during translation. This edit increases the emphasis by formatting the original line, and adding a "banned monetization" that more explicitly states vanilla cosmetics cannot be sold.