### PR TITLE
Fixes Discord channel name

### DIFF
--- a/ServerUpdateNotifications.md
+++ b/ServerUpdateNotifications.md
@@ -4,8 +4,8 @@ Change logs are available on the [Steam News Hub](https://store.steampowered.com
 
 ## Discord
 
-Messages are posted to the #steam-dedicated-server-updates text channel on the [Official Discord Server](https://discord.gg/unturned) via web hook. Each message has fields with the game version number and Steam build ID.
+Messages are posted to the #dedicated-server-updates text channel on the [Official Discord Server](https://discord.gg/unturned) via web hook. Each message has fields with the game version number and Steam build ID.
 
 ## RSS
 
-Each release is posted to an RSS feed here with the game version number and Steam build ID: https://smartlydressedgames.com/rss/unturned-steam-dedicated-server-updates.xml
+Each release is posted to an RSS feed on the Smartly Dressed Games website, with the game version number and Steam build ID: https://smartlydressedgames.com/rss/unturned-steam-dedicated-server-updates.xml


### PR DESCRIPTION
The channel is just called "#dedicated-server-updates".