### PR TITLE
ZombieDifficultyAsset

### DIFF
--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -8,9 +8,7 @@ This is an [Asset v2](AssetsV2.md) class.
 Properties
 ----------
 
-**ID** *int*:
-
-**Overrides_Spawn_Chance** *bool*: 
+**Overrides_Spawn_Chance** *bool*: Defaults to true.
 
 **Crawler_Chance** *float*: 
 

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -10,6 +10,12 @@ Unique Properties
 
 **Overrides_Spawn_Chance** *bool*: Whether or not the spawn chance for zombies in the navmesh should be overridden. For example, you would set this to false if you *only* wanted to tweak properties not related to spawning behavior, such as damage thresholds for stuns. Defaults to true.
 
+**Mega_Stun_Threshold** *int*: Damage threshold for a hit to cause a stun.
+
+**Normal_Stun_Threshold** *int*: Damage threshold for a hit to cause a stun.
+
+**Allow_Horde_Beacon** *bool*: Defaults to true.
+
 Gameplay Config Properties
 --------------------------
 
@@ -40,9 +46,3 @@ Gameplay Config Properties
 **Boss_Elver_Stomper_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
 **Boss_Kuwait_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
-
-**Mega_Stun_Threshold** *int*: Damage threshold for a hit to cause a stun.
-
-**Normal_Stun_Threshold** *int*: Damage threshold for a hit to cause a stun.
-
-**Allow_Horde_Beacon** *bool*: Defaults to true.

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -8,39 +8,39 @@ This is an [Asset v2](AssetsV2.md) class.
 Unique Properties
 -----------------
 
-**Overrides_Spawn_Chance** *bool*: Whether or not the spawn chance for zombies in the navmesh should be overridden. For example, you would set this to false if you *only* wanted to tweak properties not related to spawning behavior, such as damage thresholds for stuns. Defaults to true.
+**Overrides_Spawn_Chance** *bool*: Whether or not the spawn chance for zombies in the navmesh should be overridden by the values set in this asset. For example, it may be useful to set this to `false` if you *only* wanted to tweak properties not related to spawn chances, such as the damage thresholds for stuns. Defaults to true.
 
-**Mega_Stun_Threshold** *int*: Damage threshold for a hit to cause a stun.
+**Mega_Stun_Threshold** *int*: Override the damage threshold for a hit to cause a stun.
 
-**Normal_Stun_Threshold** *int*: Damage threshold for a hit to cause a stun.
+**Normal_Stun_Threshold** *int*: Override the damage threshold for a hit to cause a stun.
 
-**Allow_Horde_Beacon** *bool*: Defaults to true.
+**Allow_Horde_Beacon** *bool*: Whether or not Horde Beacons can be placed in the navmesh. Defaults to true.
 
 Gameplay Config Properties
 --------------------------
 
-**Crawler_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**Crawler_Chance** *float*: Decimal-to-percent chance for the zombie to be a Crawler. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Sprinter_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**Sprinter_Chance** *float*: Decimal-to-percent chance for the zombie to be a Sprinter. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Flanker_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**Flanker_Chance** *float*: Decimal-to-percent chance for the zombie to be a Flanker. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Burner_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**Burner_Chance** *float*: Decimal-to-percent chance for the zombie to be a Burner. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Acid_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**Acid_Chance** *float*: Decimal-to-percent chance for the zombie to be a Acid Spitter. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Boss_Electric_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**Boss_Electric_Chance** *float*: Decimal-to-percent chance for the zombie to be a Lightningstrike Zombie Boss. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Boss_Wind_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**Boss_Wind_Chance** *float*: Decimal-to-percent chance for the zombie to be a Groundpounder Zombie Boss. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Boss_Fire_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**Boss_Fire_Chance** *float*: Decimal-to-percent chance for the zombie to be a Flamethrower Zombie Boss. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Spirit_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**Spirit_Chance** *float*: Decimal-to-percent chance for the zombie to be a Spirit. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**DL_Red_Volatile_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**DL_Red_Volatile_Chance** *float*: Decimal-to-percent chance for the zombie to be a Volatile. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**DL_Blue_Volatile_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**DL_Blue_Volatile_Chance** *float*: Decimal-to-percent chance for the zombie to be a Blue Volatile. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Boss_Elver_Stomper_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**Boss_Elver_Stomper_Chance** *float*: Decimal-to-percent chance for the zombie to be a Stomper Zombie Boss. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Boss_Kuwait_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
+**Boss_Kuwait_Chance** *float*: Decimal-to-percent chance for the zombie to be an Evil Eye Zombie Boss. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -4,3 +4,40 @@ Zombie Difficulty Asset
 Override the difficulty settings for zombies in a navmesh. For reference, official ZombieDifficulty.asset files can be found at `...\Steam\steamapps\common\Unturned\Bundles\Assets\Zombie_Difficulty`.
 
 This is an [Asset v2](AssetsV2.md) class.
+
+Properties
+----------
+
+Overrides_Spawn_Chance `bool`
+
+Crawler_Chance `float`
+
+Sprinter_Chance `float`
+
+Flanker_Chance `float`
+
+Burner_Chance `float`
+
+Acid_Chance `float`
+
+Boss_Electric_Chance `float`
+
+Boss_Wind_Chance `float`
+
+Boss_Fire_Chance `float`
+
+Spirit_Chance `float`
+
+DL_Red_Volatile_Chance `float`
+
+DL_Blue_Volatile_Chance `float`
+
+Boss_Elver_Stomper_Chance `float`
+
+Boss_Kuwait_Chance `float`
+
+Mega_Stun_Threshold `int`
+
+Normal_Stun_Threshold `int`
+
+Allow_Horde_Beacon `bool`

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -1,1 +1,4 @@
-For reference, official ZombieDifficultyAsset files can be found at `...\Steam\steamapps\common\Unturned\Bundles\Assets\Zombie_Difficulty`.
+Zombie Difficulty Asset
+=======================
+
+Override the difficulty settings for zombies in a navmesh. For reference, official ZombieDifficultyAsset files can be found at `...\Steam\steamapps\common\Unturned\Bundles\Assets\Zombie_Difficulty`.

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -8,7 +8,7 @@ This is an [Asset v2](AssetsV2.md) class.
 Unique Properties
 -----------------
 
-**Overrides_Spawn_Chance** *bool*: Whether or not the spawn chance for zombies in the navmesh should be overridden. Defaults to true.
+**Overrides_Spawn_Chance** *bool*: Whether or not the spawn chance for zombies in the navmesh should be overridden. For example, you would set this to false if you *only* wanted to tweak properties not related to spawning behavior, such as damage thresholds for stuns. Defaults to true.
 
 Gameplay Config Properties
 --------------------------

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -2,3 +2,5 @@ Zombie Difficulty Asset
 =======================
 
 Override the difficulty settings for zombies in a navmesh. For reference, official ZombieDifficultyAsset files can be found at `...\Steam\steamapps\common\Unturned\Bundles\Assets\Zombie_Difficulty`.
+
+This is an [Asset v2](AssetsV2.md) class.

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -8,38 +8,38 @@ This is an [Asset v2](AssetsV2.md) class.
 Properties
 ----------
 
-`ID` *int*:
+**ID** *int*:
 
-`Overrides_Spawn_Chance` *bool*: 
+**Overrides_Spawn_Chance** *bool*: 
 
-`Crawler_Chance` *float*: 
+**Crawler_Chance** *float*: 
 
-`Sprinter_Chance` *float*: 
+**Sprinter_Chance** *float*: 
 
-`Flanker_Chance` *float*: 
+**Flanker_Chance** *float*: 
 
-`Burner_Chance` *float*: 
+**Burner_Chance** *float*: 
 
-`Acid_Chance` *float*: 
+**Acid_Chance** *float*: 
 
-`Boss_Electric_Chance` *float*: 
+**Boss_Electric_Chance** *float*: 
 
-`Boss_Wind_Chance` *float*: 
+**Boss_Wind_Chance** *float*: 
 
-`Boss_Fire_Chance` *float*: 
+**Boss_Fire_Chance** *float*: 
 
-`Spirit_Chance` *float*: 
+**Spirit_Chance** *float*: 
 
-`DL_Red_Volatile_Chance` *float*: 
+**DL_Red_Volatile_Chance** *float*: 
 
-`DL_Blue_Volatile_Chance` *float*: 
+**DL_Blue_Volatile_Chance** *float*: 
 
-`Boss_Elver_Stomper_Chance` *float*: 
+**Boss_Elver_Stomper_Chance** *float*: 
 
-`Boss_Kuwait_Chance` *float*: 
+**Boss_Kuwait_Chance** *float*: 
 
-`Mega_Stun_Threshold` *int*: 
+**Mega_Stun_Threshold** *int*: 
 
-`Normal_Stun_Threshold` *int*: 
+**Normal_Stun_Threshold** *int*: 
 
-`Allow_Horde_Beacon` *bool*: 
+**Allow_Horde_Beacon** *bool*: 

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -1,6 +1,6 @@
 Zombie Difficulty Asset
 =======================
 
-Override the difficulty settings for zombies in a navmesh. For reference, official ZombieDifficultyAsset files can be found at `...\Steam\steamapps\common\Unturned\Bundles\Assets\Zombie_Difficulty`.
+Override the difficulty settings for zombies in a navmesh. For reference, official ZombieDifficulty.asset files can be found at `...\Steam\steamapps\common\Unturned\Bundles\Assets\Zombie_Difficulty`.
 
 This is an [Asset v2](AssetsV2.md) class.

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -19,8 +19,6 @@ Unique Properties
 Gameplay Config Properties
 --------------------------
 
-**Overrides_Spawn_Chance** *bool*: Defaults to true.
-
 **Crawler_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
 **Sprinter_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -5,8 +5,8 @@ Override the difficulty settings for zombies in a navmesh. For reference, offici
 
 This is an [Asset v2](AssetsV2.md) class.
 
-Unique Properties
------------------
+Properties Reference
+--------------------
 
 **Overrides_Spawn_Chance** *bool*: Whether or not the spawn chance for zombies in the navmesh should be overridden by the values set in this asset. For example, it may be useful to set this to `false` if you *only* wanted to tweak properties not related to spawn chances, such as the damage thresholds for stuns. Defaults to true.
 
@@ -16,8 +16,8 @@ Unique Properties
 
 **Allow_Horde_Beacon** *bool*: Whether or not Horde Beacons can be placed in the navmesh. Defaults to true.
 
-Gameplay Config Properties
---------------------------
+Spawn Chance Properties
+-----------------------
 
 **Crawler_Chance** *float*: Decimal-to-percent chance for the zombie to be a Crawler. Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -8,36 +8,38 @@ This is an [Asset v2](AssetsV2.md) class.
 Properties
 ----------
 
-Overrides_Spawn_Chance `bool`
+`ID` *int*:
 
-Crawler_Chance `float`
+`Overrides_Spawn_Chance` *bool*: 
 
-Sprinter_Chance `float`
+`Crawler_Chance` *float*: 
 
-Flanker_Chance `float`
+`Sprinter_Chance` *float*: 
 
-Burner_Chance `float`
+`Flanker_Chance` *float*: 
 
-Acid_Chance `float`
+`Burner_Chance` *float*: 
 
-Boss_Electric_Chance `float`
+`Acid_Chance` *float*: 
 
-Boss_Wind_Chance `float`
+`Boss_Electric_Chance` *float*: 
 
-Boss_Fire_Chance `float`
+`Boss_Wind_Chance` *float*: 
 
-Spirit_Chance `float`
+`Boss_Fire_Chance` *float*: 
 
-DL_Red_Volatile_Chance `float`
+`Spirit_Chance` *float*: 
 
-DL_Blue_Volatile_Chance `float`
+`DL_Red_Volatile_Chance` *float*: 
 
-Boss_Elver_Stomper_Chance `float`
+`DL_Blue_Volatile_Chance` *float*: 
 
-Boss_Kuwait_Chance `float`
+`Boss_Elver_Stomper_Chance` *float*: 
 
-Mega_Stun_Threshold `int`
+`Boss_Kuwait_Chance` *float*: 
 
-Normal_Stun_Threshold `int`
+`Mega_Stun_Threshold` *int*: 
 
-Allow_Horde_Beacon `bool`
+`Normal_Stun_Threshold` *int*: 
+
+`Allow_Horde_Beacon` *bool*: 

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -1,0 +1,1 @@
+For reference, official ZombieDifficultyAsset files can be found at `...\Steam\steamapps\common\Unturned\Bundles\Assets\Zombie_Difficulty`.

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -5,39 +5,44 @@ Override the difficulty settings for zombies in a navmesh. For reference, offici
 
 This is an [Asset v2](AssetsV2.md) class.
 
-Properties
-----------
+Unique Properties
+-----------------
+
+**Overrides_Spawn_Chance** *bool*: Whether or not the spawn chance for zombies in the navmesh should be overridden. Defaults to true.
+
+Gameplay Config Properties
+--------------------------
 
 **Overrides_Spawn_Chance** *bool*: Defaults to true.
 
-**Crawler_Chance** *float*: 
+**Crawler_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Sprinter_Chance** *float*: 
+**Sprinter_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Flanker_Chance** *float*: 
+**Flanker_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Burner_Chance** *float*: 
+**Burner_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Acid_Chance** *float*: 
+**Acid_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Boss_Electric_Chance** *float*: 
+**Boss_Electric_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Boss_Wind_Chance** *float*: 
+**Boss_Wind_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Boss_Fire_Chance** *float*: 
+**Boss_Fire_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Spirit_Chance** *float*: 
+**Spirit_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**DL_Red_Volatile_Chance** *float*: 
+**DL_Red_Volatile_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**DL_Blue_Volatile_Chance** *float*: 
+**DL_Blue_Volatile_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Boss_Elver_Stomper_Chance** *float*: 
+**Boss_Elver_Stomper_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Boss_Kuwait_Chance** *float*: 
+**Boss_Kuwait_Chance** *float*: Defaults to 0. Requires `Overrides_Spawn_Chance` to be true.
 
-**Mega_Stun_Threshold** *int*: 
+**Mega_Stun_Threshold** *int*: Damage threshold for a hit to cause a stun.
 
-**Normal_Stun_Threshold** *int*: 
+**Normal_Stun_Threshold** *int*: Damage threshold for a hit to cause a stun.
 
-**Allow_Horde_Beacon** *bool*: 
+**Allow_Horde_Beacon** *bool*: Defaults to true.


### PR DESCRIPTION
Adds a documentation file named **ZombieDifficultyAsset.md**.

Note: although the official/vanilla ZombieDifficulty.asset files have an "ID" property, this isn't used by the class and the asset file works fine without it, so I haven't included it on the documentation.