### PR TITLE
Expand on wording of MTX rules

### DIFF
--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -9,6 +9,8 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 ## Recent changes
 
+**January 10, 2022 update:**
+
 **October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 
 ## Monetization Types
@@ -46,8 +48,6 @@ Players can filter the in-game server list by this field. It is not required to 
 
 The "Monetization" field in each server's Config.json file defaults to `Unspecified`. If you are unsure what to configure your server's monetization type as, then you can leave it unspecified.
 
-Servers that offer any "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage), such as selling "kits" containing items or vehicles, should also use this option.
-
 ### `None`
 
 Servers that are entirely unmonetized, or only offer a donation option, can use the `None` value.
@@ -55,6 +55,10 @@ Servers that are entirely unmonetized, or only offer a donation option, can use 
 ### `NonGameplay`
 
 Servers that only offer microtransactions that do not provide a gameplay advantage can use the `NonGameplay` value. For example, selling custom weapon skins and chat colors would not be a gameplay advantage.
+
+### `Monetized`
+
+Servers that offer any "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage), such as selling "kits" containing items or vehicles, should also use this option.
 
 ## Deceptive Pricing
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -17,7 +17,7 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 Warnings for breaking the monetization rules first began being sent out on May 28, 2021. The monetization rules have now been in full effect since June 11, 2021.
 
-Hosts are allowed to sell permanent benefits and monthly subscriptions. Consumable microtransactions are **not** allowed. A consumable microtransaction is anything that can be permanently consumed, lost, stolen, or destroyed. If something cannot be permanently lost, then it is not considered a consumable.
+Hosts are allowed to sell permanent benefits and monthly subscriptions. Consumable microtransactions are **not** allowed. A consumable microtransaction is anything that can be permanently consumed, lost, stolen, or destroyed. If it cannot be permanently lost, then it is not considered a consumable.
 
 ## Examples
 
@@ -27,14 +27,15 @@ This section will provide *examples* of allowed/banned monetization options. It 
 
 - Accepting donations.
 - Selling permanent or monthly subscription access to play on the server(s).
-- Selling ranks, kits, unlocks, benefits, etc. available permanently or for the duration of the monthly subscription. Timers or cooldowns are fine.
+- Selling ranks, unlocks, benefits, etc. available permanently, or for the duration of the monthly subscription. Timers or cooldowns are fine.
+- Selling reusable kits—which are available permanently, or for the duration of the monthly subscription—containing in-game items. Timers or cooldowns are fine.
 - Selling **custom** cosmetics like custom skins, name tags, chat colors, etc. available permanently or for the duration of the monthly subscription.
 - Selling services or commissions, for example a modder taking commissions for new content that gets added to the server for all players.
 
 ### Examples of banned monetization:
 
-- Selling in-game items like weapons, ammunition, supplies, bases, etc. that can be permanently lost, stolen, or destroyed.
-- Selling in-game vehicles that can be permanently lost, stolen, or destroyed.
+- Selling individual in-game items like weapons, ammunition, supplies, bases, etc. that can be permanently lost, stolen, or destroyed.
+- Selling individual in-game vehicles that can be permanently lost, stolen, or destroyed.
 - Selling experience points.
 - Selling currency.
 - Selling ranks, kits, unlocks, benefits, etc. which stack with themselves as a loophole.

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -56,10 +56,6 @@ Servers that are entirely unmonetized, or only offer a donation option, can use 
 
 Servers that only offer microtransactions that do not provide a gameplay advantage can use the `NonGameplay` value. For example, selling custom weapon skins and chat colors would qualify as not being a gameplay advantage.
 
-### `Gameplay`
-
-Servers that offer "pay-to-win" microtransactions that provide a gameplay advantage can use the `Gameplay` value. For example, selling "kits" would be a gameplay advantage.
-
 ## Online Conduct
 
 View the Steam rules and guidelines here: https://support.steampowered.com/kb_article.php?ref=4045-USHJ-3810

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -9,7 +9,7 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 ## Recent changes
 
-**January 10, 2022 update:** We've revised a lot of the wording and formatting to make the monetization rules clearer with regards to what is/isn't currently allowed. For example, we've clarified on what is considered a "consumable microtransaction", created a dedicated section for deceptive pricing and discounts, and added a couple new examples. We've also added more information about the monetization filter, its purpose, and which of the four options you should use.
+**January 10, 2022 update:** We've revised a lot of the wording and formatting to make the monetization rules clearer with regards to what is/isn't currently allowed. For example, we've clarified on what is considered a "consumable microtransaction", created a dedicated section for deceptive pricing and discounts, and added a couple new examples. We've also added more information about the monetization filter, its purpose, and which of the four options your server should use.
 
 **October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -9,7 +9,7 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 ## Recent changes
 
-**January 10, 2022 update:** We've revised a lot of the wording and formatting to make the monetization rules clearer with regards to what is/isn't currently allowed. For example, we've clarified on what is considered a "consumable microtransaction", created a dedicated section for deceptive pricing and discounts, and added a couple new examples. We've also added more information about the monetization filter, its purpose, and which of the four options your server should use.
+**January 10, 2022 update:** Much of the wording and formatting has been revised to make the monetization rules clear, with regards to what is (or isn't) currently allowed. For example, we've clarified on what is considered a "consumable microtransaction", created a dedicated section for deceptive pricing and discounts, and added a couple new examples. We've also added more information about the monetization filter, its purpose, and which of the four options your server should use.
 
 **October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -9,7 +9,7 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 ## Recent changes
 
-**January 10, 2022 update:** Much of the wording and formatting has been revised to make the monetization rules clear, with regards to what is (or isn't) currently allowed. For example, we've clarified on what is considered a "consumable microtransaction", created a dedicated section for deceptive pricing and discounts, and added a couple new examples. We've also added more information about the monetization filter, its purpose, and which of the four options your server should use.
+**January 10, 2022 update:** Many of the rules have been revised to be clearer, with regards to what is (or isn't) currently allowed. "Consumable microtransaction" is better defined, there are a couple of new examples, and deceptive pricing has its own dedicated asection. The monetization filter section also includes more information about the filter, its purpose, and which of the four options (including a newer "Monetized" option) your server should use.
 
 **October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -9,7 +9,7 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 ## Recent changes
 
-**January 10, 2022 update:** We've revised a lot of the wording and formatting to make the monetization rules clearer with regards to what is/isn't currently allowed. For example, we've clarified on what is considered a "consumable microtransaction", created a dedicated section regarding deceptive pricing and discounts, and added information about all four monetization filter types (including a newer "Monetized" filter that wasn't previously documented).
+**January 10, 2022 update:** We've revised a lot of the wording and formatting to make the monetization rules clearer with regards to what is/isn't currently allowed. For example, we've clarified on what is considered a "consumable microtransaction", created a dedicated section for deceptive pricing and discounts, and added a couple new examples. We've also added more information about the monetization filter, its purpose, and which of the four options you should use.
 
 **October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -7,7 +7,7 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 [View Moderation List](https://smartlydressedgames.com/UnturnedHostBans/index.html)
 
-## Recent updates
+## Recent changes
 
 **October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -9,7 +9,7 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 ## Recent changes
 
-**January 10, 2022 update:** Many of the rules have been revised to be clearer, with regards to what is (or isn't) currently allowed. "Consumable microtransaction" is better defined, there are a couple of new examples, and deceptive pricing has its own dedicated asection. The monetization filter section also includes more information about the filter, its purpose, and which of the four options (including a newer "Monetized" option) your server should use.
+**January 10, 2022 revisions:** Many of the rules have been revised to be clearer, with regards to what is (or isn't) currently allowed. "Consumable microtransaction" is better defined, there are a couple of new examples, and deceptive pricing has its own dedicated asection. The monetization filter section also includes more information about the filter, its purpose, and which of the four options (including a newer "Monetized" option) your server should use.
 
 **October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -33,8 +33,8 @@ This section will provide *examples* of allowed/banned monetization options. It 
 
 ### Examples of banned monetization:
 
-- Selling in-game items like weapons, ammunition, supplies, bases, etc.
-- Selling in-game vehicles.
+- Selling in-game items like weapons, ammunition, supplies, bases, etc. that can be permanently lost, stolen, or destroyed.
+- Selling in-game vehicles that can be permanently lost, stolen, or destroyed.
 - Selling experience points.
 - Selling currency.
 - Selling ranks, kits, unlocks, benefits, etc. which stack with themselves as a loophole.

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -46,7 +46,7 @@ Players can filter the in-game server list by this field. It is not required to 
 
 ### `Unspecified`
 
-The "Monetization" field in each server's Config.json file defaults to `Unspecified`. Ideally, this field should be set to whichever value accurately describes your server's monetization practices. This field should be configured truthfully, as players can filter the in-game server list by this field.
+The "Monetization" field in each server's Config.json file defaults to `Unspecified`. If you are unsure what to configure your server's monetization type as, then you can leave it unspecified.
 
 ### `None`
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -11,8 +11,6 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 **October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 
-**August 2, 2021 update:** Fictitious and deceptive pricing is not allowed. For example, lying that a discount is nearly expired, or pretending the price is discounted when it has never been at full price. We would strongly advise following [Steam's discounting rules](https://partner.steamgames.com/doc/marketing/discounts) to help avoid breaking any real-world laws.
-
 ## Monetization Types
 
 Warnings for breaking the monetization rules first began being sent out on May 28, 2021. The monetization rules have now been in full effect since June 11, 2021.
@@ -54,13 +52,19 @@ Servers that are entirely unmonetized, or only offer a donation option, can use 
 
 ### `NonGameplay`
 
-Servers that only offer microtransactions that do not provide a gameplay advantage can use the `NonGameplay` value. For example, selling custom weapon skins and chat colors would qualify as not being a gameplay advantage.
+Servers that only offer microtransactions that do not provide a gameplay advantage can use the `NonGameplay` value. For example, selling custom weapon skins and chat colors would not be a gameplay advantage.
+
+### `Gameplay`
+
+Servers that offer any "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage) can use the `Gameplay` value. For example, selling "kits" containing items or vehicles would be a gameplay advantage.
+
+## Deceptive Pricing
+
+Fictitious and deceptive pricing is not allowed. For example: lying that a discount is nearly expired, or pretending the price is discounted when it has never been at the listed full price. We would strongly advise following [Steam's discounting rules](https://partner.steamgames.com/doc/marketing/discounts) to help avoid breaking any real-world laws.
 
 ## Online Conduct
 
-View the Steam rules and guidelines here: https://support.steampowered.com/kb_article.php?ref=4045-USHJ-3810
-
-Repeated offenders of Steam rules and guidelines will be banned.
+Repeated offenders of [Steam's rules and guidelines](https://support.steampowered.com/kb_article.php?ref=4045-USHJ-3810) will be banned.
 
 ## Workshop File Copyright Infringement
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -9,7 +9,7 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 ## Recent changes
 
-**January 10, 2022 revisions:** Many of the rules have been revised to be clearer, with regards to what is (or isn't) currently allowed. "Consumable microtransaction" is better defined, there are a couple of new examples, and deceptive pricing has its own dedicated asection. The monetization filter section also includes more information about the filter, its purpose, and which of the four options (including a newer "Monetized" option) your server should use.
+**January 13, 2022 revisions:** Many of the rules have been revised to be clearer, with regards to what is (or isn't) currently allowed. "Consumable microtransaction" is better defined, there are a couple of new examples, and deceptive pricing has its own dedicated asection. The monetization filter section also includes more information about the filter, its purpose, and which of the four options (including a newer "Monetized" option) your server should use.
 
 **October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -58,7 +58,7 @@ Servers that only offer microtransactions that do not provide a gameplay advanta
 
 ### `Monetized`
 
-Servers that offer *any* "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage)—such as selling "kits" containing items or vehicles—should use this option.
+Servers that offer *any* "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage)—such as selling "kits" containing items or vehicles—should use the `Monetized` option.
 
 ## Deceptive Pricing
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -9,7 +9,7 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 ## Recent changes
 
-**January 10, 2022 update:**
+**January 10, 2022 update:** We've revised a lot of the wording and formatting to make the monetization rules clearer with regards to what is/isn't currently allowed. For example, we've clarified on what is considered a "consumable microtransaction", created a dedicated section regarding deceptive pricing and discounts, and added information about all four monetization filter types (including a newer "Monetized" filter that wasn't previously documented).
 
 **October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -17,7 +17,7 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 Warnings for breaking the monetization rules first began being sent out on May 28, 2021. The monetization rules have now been in full effect since June 11, 2021.
 
-Hosts are allowed to sell permanent benefits and monthly subscriptions. Consumable microtransactions are **not** allowed.
+Hosts are allowed to sell permanent benefits and monthly subscriptions. Consumable microtransactions are **not** allowed. A consumable microtransaction is anything that can be permanently consumed, lost, stolen, or destroyed. If something cannot be permanently lost, then it is not considered a consumable.
 
 ## Examples
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -28,7 +28,7 @@ This section will provide *examples* of allowed/banned monetization options. It 
 - Accepting donations.
 - Selling permanent or monthly subscription access to play on the server(s).
 - Selling ranks, unlocks, benefits, etc. available permanently, or for the duration of the monthly subscription. Timers or cooldowns are fine.
-- Selling reusable kits—which are available permanently, or for the duration of the monthly subscription—containing in-game items. Timers or cooldowns are fine.
+- Selling reusable "kits"—which are available permanently, or for the duration of the monthly subscription—containing in-game items. Timers or cooldowns are fine.
 - Selling **custom** cosmetics like custom skins, name tags, chat colors, etc. available permanently or for the duration of the monthly subscription.
 - Selling services or commissions, for example a modder taking commissions for new content that gets added to the server for all players.
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -46,7 +46,7 @@ Players can filter the in-game server list by this field. It is not required to 
 
 The "Monetization" field in each server's Config.json file defaults to `Unspecified`. If you are unsure what to configure your server's monetization type as, then you can leave it unspecified.
 
-Servers that offer any "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage), such as selling "kits" containing items or vehicles, should use this option.
+Servers that offer any "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage), such as selling "kits" containing items or vehicles, should also use this option.
 
 ### `None`
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -7,11 +7,13 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 [View Moderation List](https://smartlydressedgames.com/UnturnedHostBans/index.html)
 
-## Monetization Types
+## Recent updates
 
 **October 16, 2022 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 
 **August 2, 2021 update:** Fictitious and deceptive pricing is not allowed. For example, lying that a discount is nearly expired, or pretending the price is discounted when it has never been at full price. We would strongly advise following [Steam's discounting rules](https://partner.steamgames.com/doc/marketing/discounts) to help avoid breaking any real-world laws.
+
+## Monetization Types
 
 Warnings for breaking the monetization rules first began being sent out on May 28, 2021. The monetization rules have now been in full effect since June 11, 2021.
 
@@ -19,7 +21,7 @@ Hosts are allowed to sell permanent benefits and monthly subscriptions. Consumab
 
 ## Examples
 
-This section will provide *examples* of allowed/banned monetization options. It is not an exhaustive list of every possible monetization strategy. If something is not on this list, 
+This section will provide *examples* of allowed/banned monetization options. It is not an exhaustive list of every possible monetization strategy.
 
 ### Examples of allowed monetization:
 
@@ -29,7 +31,8 @@ This section will provide *examples* of allowed/banned monetization options. It 
 - Selling **custom** cosmetics like custom skins, name tags, chat colors, etc. available permanently or for the duration of the monthly subscription.
 - Selling services or commissions, for example a modder taking commissions for new content that gets added to the server for all players.
 
-Examples of banned monetization:
+### Examples of banned monetization:
+
 - Selling in-game items like weapons, ammunition, supplies, bases, etc.
 - Selling in-game vehicles.
 - Selling experience points.

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -58,7 +58,7 @@ Servers that only offer microtransactions that do not provide a gameplay advanta
 
 ### `Monetized`
 
-Servers that offer any "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage), such as selling "kits" containing items or vehicles, should also use this option.
+Servers that offer *any* "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage)—such as selling "kits" containing items or vehicles—should use this option.
 
 ## Deceptive Pricing
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -46,6 +46,8 @@ Players can filter the in-game server list by this field. It is not required to 
 
 The "Monetization" field in each server's Config.json file defaults to `Unspecified`. If you are unsure what to configure your server's monetization type as, then you can leave it unspecified.
 
+Servers that offer any "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage), such as selling "kits" containing items or vehicles, should use this option.
+
 ### `None`
 
 Servers that are entirely unmonetized, or only offer a donation option, can use the `None` value.
@@ -53,10 +55,6 @@ Servers that are entirely unmonetized, or only offer a donation option, can use 
 ### `NonGameplay`
 
 Servers that only offer microtransactions that do not provide a gameplay advantage can use the `NonGameplay` value. For example, selling custom weapon skins and chat colors would not be a gameplay advantage.
-
-### `Gameplay`
-
-Servers that offer any "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage) can use the `Gameplay` value. For example, selling "kits" containing items or vehicles would be a gameplay advantage.
 
 ## Deceptive Pricing
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -17,7 +17,12 @@ Warnings for breaking the monetization rules first began being sent out on May 2
 
 Hosts are allowed to sell permanent benefits and monthly subscriptions. Consumable microtransactions are **not** allowed.
 
-Examples of allowed monetization:
+## Examples
+
+This section will provide *examples* of allowed/banned monetization options. It is not an exhaustive list of every possible monetization strategy. If something is not on this list, 
+
+### Examples of allowed monetization:
+
 - Accepting donations.
 - Selling permanent or monthly subscription access to play on the server(s).
 - Selling ranks, kits, unlocks, benefits, etc. available permanently or for the duration of the monthly subscription. Timers or cooldowns are fine.
@@ -34,7 +39,23 @@ Examples of banned monetization:
 
 ## Monetization Filter
 
-The "Monetization" field in each server's Config.json file defaults to "Unspecified", but can be set to "None" or "NonGameplay". If configuring this field please ensure to be truthful. "None" is for unmonetized or donation-only servers, and "NonGameplay" is for servers with purchases that do not provide a gameplay advantage. Players filtering the server list by "NonGameplay" will also see "None" servers.
+Players can filter the in-game server list by this field. It is not required to configure this field, but ideally it should be set to whichever value accurately describes your server's monetization practices. When configured, this field must be configured truthfully.
+
+### `Unspecified`
+
+The "Monetization" field in each server's Config.json file defaults to `Unspecified`. Ideally, this field should be set to whichever value accurately describes your server's monetization practices. This field should be configured truthfully, as players can filter the in-game server list by this field.
+
+### `None`
+
+Servers that are entirely unmonetized, or only offer a donation option, can use the `None` value.
+
+### `NonGameplay`
+
+Servers that only offer microtransactions that do not provide a gameplay advantage can use the `NonGameplay` value. For example, selling custom weapon skins and chat colors would qualify as not being a gameplay advantage.
+
+### `Gameplay`
+
+Servers that offer "pay-to-win" microtransactions that provide a gameplay advantage can use the `Gameplay` value. For example, selling "kits" would be a gameplay advantage.
 
 ## Online Conduct
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -28,7 +28,7 @@ This section will provide *examples* of allowed/banned monetization options. It 
 - Accepting donations.
 - Selling permanent or monthly subscription access to play on the server(s).
 - Selling ranks, unlocks, benefits, etc. available permanently, or for the duration of the monthly subscription. Timers or cooldowns are fine.
-- Selling reusable "kits"—which are available permanently, or for the duration of the monthly subscription—containing in-game items. Timers or cooldowns are fine.
+- Selling reusable "kits"—which are reusable permanently, or for the duration of the monthly subscription—containing in-game items. Timers or cooldowns are fine.
 - Selling **custom** cosmetics like custom skins, name tags, chat colors, etc. available permanently or for the duration of the monthly subscription.
 - Selling services or commissions, for example a modder taking commissions for new content that gets added to the server for all players.
 


### PR DESCRIPTION
This PR does the following:

1. Adds a section for listing recent updates, rather than just adding them to the top of the doc. Currently, this just contains the "October 16, 2022 clarification" about skin changers.

2. Adds a section about deceptive pricing, and moved the relevant information from the "August 2, 2021 update" snippet into it.

3. Adds a new section for monetization examples, and moves the preexisting lists into it.  Clarifies that the list is not intended to be exhaustive.

4. Clarifies on banned item/vehicle consumables (the ability for them to be permanently lost, stolen, or destroyed).

5. Greatly expands on the "Monetization Filter" section. The lead contains general information about the field and how players can use it. There are now three subsections beneath – one for each filter type. Each subsection includes the value you'd set, a brief explanation of who should you use it, and a basic example.