### PR TITLE
Adjust heading markup for .RST

### DIFF
--- a/AnimalAsset.md
+++ b/AnimalAsset.md
@@ -1,3 +1,6 @@
+Animal Assets
+=============
+
 **GUID** *32-digit hexadecimal*: Refer to [GUID](/GUID.md) documentation.
 
 **Type** *enum* (`Animal`)

--- a/AssetBundleCustomData.md
+++ b/AssetBundleCustomData.md
@@ -1,10 +1,12 @@
-# Asset Bundle Custom Data
+Asset Bundle Custom Data
+========================
 
 Unity `ScriptableObject` which can optionally be created in a [Master Bundle's](AssetBundles.md) root for Unturned-specific asset bundle metadata.
 
 `Owner Workshop File Id` *uint64*: ID of a file published to the Steam Workshop. If Unturned is loading this asset bundle from a Steam workshop file but the file ID does not match then loading will be canceled. Prevents the asset bundle from being easily copied/stolen.
 
-## How to Set Owner Workshop File
+How to Set Owner Workshop File
+------------------------------
 
 1. Within the Unity project window find your master bundle's root folder. This is the same as the Asset_Prefix specified in your MasterBundle.dat file. For example Hawaii's root folder is Assets/HawaiiMasterBundle.
 

--- a/AssetBundles.md
+++ b/AssetBundles.md
@@ -1,10 +1,12 @@
-# Asset Bundles
+Asset Bundles
+=============
 
 The game loads textures, audio, meshes, prefabs, etc. from **Unity Asset Bundles** at runtime. How these are setup and used has evolved over the years from individual *.unity3d bundles to *.content bundles to *.masterbundle files.
 
 [Master Bundles](#master-bundles) should be used for essentially all new projects.
 
-## Tool Setup
+Tool Setup
+----------
 
 Prior to using any of these tools they must be imported into a Unity project
 
@@ -13,11 +15,12 @@ Prior to using any of these tools they must be imported into a Unity project
 3. Navigate to the Bundles/Sources directory.
 4. Import the Project.unitypackage.
 
-## Master Bundles (*.masterbundle)
+Master Bundles (\*.masterbundle)
+--------------------------------
 
 Most official files including curated maps have been transitioned to master bundles, and they will be used for the forseeable future.
 
-### File Setup:
+### File Setup
 
 Master bundles can be loaded from any directory the game loads *.dat files from. Unless an override is specified, the nearest master bundle in the file hierarchy is used. While loading each directory is checked for a MasterBundle.dat file signalling the presence of a master bundle. For example, refer to the core.masterbundle in the Bundles directory.
 
@@ -33,7 +36,7 @@ MasterBundle.dat can set the following keys:
 	// Version 3 is Unity 2018.4 LTS. Older versions have shader consolidation enabled for backwards compatibility.
 	Asset_Bundle_Version 3
 
-Individual asset *.dats can set the following keys:
+Individual asset \*.dats can set the following keys:
 
 	// Name of master bundle to load files from.
 	Master_Bundle_Override core.masterbundle
@@ -45,7 +48,7 @@ Individual asset *.dats can set the following keys:
 	// Used by notes to share a common object prefab.
 	Bundle_Override_Path /Objects/Medium/Furniture/Note
 
-### Tool Usage:
+### Tool Usage
 
 1. Follow _Tool Setup_ instructions.
 2. Open the tool from the Window > Unturned > Master Bundle Tool menu.
@@ -56,15 +59,16 @@ Individual asset *.dats can set the following keys:
 7. Click Export.
 8. (optional) When redistributing the asset bundle the "multiplatform" toggle should be enabled. This ensures the appropriate shaders for each platform are included, and exports a ".hash" file so the server can validate client asset bundle integrity.
 
-### Motivations:
+### Motivations
 
-When upgrading to Unity 2017.4 LTS it became apparent that all asset bundles would have to be re-exported from Unity due to shader compatibility changes. This would be an incredible amount of files, so it was time to re-approach the *.content issue in a way that could quickly convert all existing content. This was handled by keeping the file hierarchy 1:1 and guessing the file extension for the by-name loading.
+When upgrading to Unity 2017.4 LTS it became apparent that all asset bundles would have to be re-exported from Unity due to shader compatibility changes. This would be an incredible amount of files, so it was time to re-approach the \*.content issue in a way that could quickly convert all existing content. This was handled by keeping the file hierarchy 1:1 and guessing the file extension for the by-name loading.
 
-## Individual Asset Bundles (*.unity3d)
+Individual Asset Bundles (\*.unity3d)
+-------------------------------------
 
 Most official files have transitioned to the master bundle system, but some uses still exist like the per-map road textures.
 
-### Tool Usage:
+### Tool Usage
 
 1. Follow _Tool Setup_ instructions.
 2. Open the tool from the Window > Unturned > Bundle Tool menu.
@@ -72,11 +76,12 @@ Most official files have transitioned to the master bundle system, but some uses
 4. Click Grab to preview which assets will be exported.
 5. Click Bundle to choose a destination for the asset bundle file.
 
-### Motivations:
+### Motivations
 
 When beginning development of 3.0, it was key to support runtime loading of custom modded content. At the time files in asset bundles were loaded by name without extension, so each game type looked for specific names like "Item", "Object", "Animal", etc. The .unity3d extension was chosen for web browser compatibility. Obviously this system did not age well.
 
-## Content Bundles (*.content) *DEPRECATED*
+Content Bundles (\*.content) *DEPRECATED*
+-----------------------------------------
 
 This format was historically used by terrain, material palettes, and radio songs. After the April 23, 2021 patch (version 3.21.15.0) these assets can all use master bundles instead. As of the February 25, 2022 patch (version 3.22.4.0) any remaining support for content bundles has been removed. New references should use a master bundle name and relative path for the "Name" and "Path" properties.
 

--- a/Bitmask.md
+++ b/Bitmask.md
@@ -1,7 +1,9 @@
-# Bitmask
+Bitmask
+=======
 
 [Recommended Wikipedia Article](https://en.wikipedia.org/wiki/Mask_(computing))
 
-## Weather Example
+Weather Example
+---------------
 
 Rain's default mask is 1 (0b01), and snow's default mask is 2 (0b10). An ambience volume could enable both with 3 (0b11) or neither with 0 (0b00).

--- a/EditorAssetRedirectors.md
+++ b/EditorAssetRedirectors.md
@@ -1,4 +1,5 @@
-# Editor Asset Redirectors
+Editor Asset Redirectors
+========================
 
 If many objects need to be replaced on a map the old object guid can be redirected to a new guid rather than manually replacing them. This works similarly to the automatic holiday object replacements, but applies while loading a map in the editor, and changes are kept when the map is saved.
 

--- a/EffectAsset.md
+++ b/EffectAsset.md
@@ -1,5 +1,5 @@
-Effects
-=======
+Effect Assets
+=============
 
 **GUID** *32-digit hexadecimal*: Refer to [GUID](GUID.md) documentation.
 

--- a/Foliage.md
+++ b/Foliage.md
@@ -1,4 +1,5 @@
-# Foliage
+Foliage
+=======
 
 This is an [Asset v2](AssetsV2.md) class.
 
@@ -6,7 +7,8 @@ There are sub-types of foliage asset for different uses, most notably instanced 
 1. Different biomes or levels can use the same trees with different parameters. For example a dense forest material with less dense forest surrounding it, or using tree assets from a different map with custom configuration.
 2. Eventually the resource system should be converted into a regular objects (this will be automatic) but most objects do not need foliage parameters.
 
-## FoliageResourceInfoAsset Properties Reference
+FoliageResourceInfoAsset Properties Reference
+---------------------------------------------
 
 `Resource` [Asset Pointer](AssetPtr.md): actual tree to spawn.
 
@@ -22,7 +24,8 @@ There are sub-types of foliage asset for different uses, most notably instanced 
 
 `Max_Angle` *float*: [0, 90] degrees only spawn if surface angle is less than this value. For example a tree not growing on slopes steeper than 30 degrees.
 
-## Upgrade Devkit Foliage from V1 to V2
+Upgrade Devkit Foliage from V1 to V2
+------------------------------------
 
 Note: maps with auto-converted terrain from the 3.22.8.0 update will already have been converted to V2.
 

--- a/GameServerLoginTokens.md
+++ b/GameServerLoginTokens.md
@@ -1,14 +1,17 @@
-# Game Server Login Tokens
+Game Server Login Tokens
+========================
 
 Beginning in version 3.20.4.0 Unturned dedicated servers can be authenticated using a **Game Server Login Token** or **GSLT**. After version 3.21.31.0 anonymous servers (without GSLT) are hidden from the internet server list.
 
-## Creating GSLTs
+Creating GSLTs
+--------------
 
 You can manually create GSLTs while logged in with your Steam account here: https://steamcommunity.com/dev/managegameservers
 
 Use Unturned's app ID `304930`, and a memo to remind you which server the token is for.
 
-## Unturned Configuration
+Unturned Configuration
+----------------------
 
 The GSLT can be set in one of two places depending on your preference:
 
@@ -18,6 +21,7 @@ OR
 
 - Using the `GSLT` command during startup. This can be specified in the `Commands.dat` file or on the command-line.
 
-## Automating GSLTs
+Automating GSLTs
+----------------
 
 Valve provides an `IGameServersService` web API for managing GSLTs. Consult their documentation here: https://partner.steamgames.com/doc/webapi/IGameServersService

--- a/Glazier.md
+++ b/Glazier.md
@@ -1,4 +1,5 @@
-# Glazier
+Glazier
+=======
 
 Unity (the game engine Unturned runs on) has three different incompatible UI systems, each with different bugs:
 1. IMGUI
@@ -9,7 +10,8 @@ Unturned has a feature nicknamed **Glazier** which abstracts the underlying UI s
 
 uGUI is Unity's current recommended UI system, but unfortunately some players run into visual artifacts and flickering UI with it. In those cases enabling IMGUI is recommended.
 
-## IMGUI
+IMGUI
+-----
 
 You can opt to use Unity's legacy UI system, IMGUI, by enabling a command-line argument:
 1. Right-click Unturned in your Steam library
@@ -27,7 +29,8 @@ Cons:
 - Plugin UIs are sorted underneath the game UI i.e. plugin UI cannot overlay.
 - Rich text does not fade out in chat.
 
-## uGUI
+uGUI
+----
 
 This is Unturned's current default UI system, so opting in is not necessary.
 

--- a/ItemAsset/BarricadeAsset.md
+++ b/ItemAsset/BarricadeAsset.md
@@ -1,4 +1,5 @@
-# Barricade Assets
+Barricade Assets
+================
 
 Noting these here for now until barricade properties are documented:
 

--- a/ItemAsset/FuelAsset.md
+++ b/ItemAsset/FuelAsset.md
@@ -1,5 +1,5 @@
 Fuel Assets
-==========
+===========
 
 Temporarily noting this here, until fuel assets are properly documented.
 

--- a/ItemAsset/GripAsset.md
+++ b/ItemAsset/GripAsset.md
@@ -1,5 +1,5 @@
 Grip Assets
-============
+===========
 
 Grip attachments are inventory items that can be attached to ranged weapons.
 

--- a/ItemAsset/README.md
+++ b/ItemAsset/README.md
@@ -1,5 +1,5 @@
-Items
-=====
+Item Assets
+===========
 
 Item assets are an [Assets v1](/AssetsV1.md) class. See [AssetBundles.md](/AssetBundles.md) for full documentation regarding asset bundles.
 

--- a/Layers.md
+++ b/Layers.md
@@ -1,8 +1,10 @@
-# Layers
+Layers
+======
 
 Upfront: obviously Unturned makes poor use of Unity's Layers. This document exists as much for my personal reference as yours. My only defense is that these layers are entrenched from the earliest versions back in 2013, when I was 15 or 16.
 
-## Overview
+Overview
+--------
 
 Built-in Layers
 - 0 Default
@@ -37,7 +39,8 @@ User Layers
 - 30 Trap: typically trigger colliders including rocket launcher projectiles and kill volumes.
 - 31 Ground2: no longer used after old maps were converted to terrain tiles. Previously this was for out-of-bounds terrain. Reserved for future use.
 
-## Layer Collision Matrix
+Layer Collision Matrix
+----------------------
 
 Note that these comments do **NOT** apply to collision queries like raycasts, spherecasts, etc.
 

--- a/LevelAsset.md
+++ b/LevelAsset.md
@@ -31,7 +31,8 @@ For examples check the `Assets/Levels` directory.
 
 This is an [Asset v2](AssetsV2.md) class.
 
-## Schedulable Weather Properties
+Schedulable Weather Properties
+------------------------------
 
 `Asset` [Asset Pointer](AssetPtr.md) to a [Weather Asset](WeatherAsset.md).
 
@@ -43,7 +44,8 @@ This is an [Asset v2](AssetsV2.md) class.
 
 `Max_Duration` *float*: Maximum number of in-game days before the weather event will end.
 
-## Skill Rule Properties
+Skill Rule Properties
+---------------------
 
 `Id` string: Name of skill, for example Sharpshooter.
 
@@ -53,7 +55,8 @@ This is an [Asset v2](AssetsV2.md) class.
 
 `Cost_Multiplier` *float*: multiplier for XP upgrade cost.
 
-## Music Properties
+Music Properties
+----------------
 
 `Loop` [Master Bundle Pointer](MasterBundlePtr.md): looping audio clip played until loading finishes.
 

--- a/LevelBatching.md
+++ b/LevelBatching.md
@@ -1,4 +1,5 @@
-# Level Batching
+Level Batching
+==============
 
 This article is intended for map developers and explains how to maximize draw call batching.
 
@@ -8,7 +9,8 @@ For background information on the purpose of batching:
 - [Texture atlas (Wikipedia)](https://en.wikipedia.org/wiki/Texture_atlas)
 - [Static batching (Unity docs)](https://docs.unity3d.com/Manual/static-batching.html)
 
-## Enabling batching in your level
+Enabling batching in your level
+-------------------------------
 
 By default batching is disabled because some parts of the level may be incompatible (causing graphical bugs), the texture atlas might be too big, it might worsen performance, etc. Publishing your map with batching enabled is only recommended after double-checking each location in singleplayer. (batching is disabled in the level editor) You can test it by adding this property to your level's `Config.json` file:
 
@@ -16,11 +18,13 @@ By default batching is disabled because some parts of the level may be incompati
 
 The purpose of the version number is to allow future improvements without potentially breaking existing maps. For example, if atlas generation is supported for more shaders in an update it might behave unexpectedly, so those shaders would be excluded on older versions.
 
-## Purpose of atlas generation
+Purpose of atlas generation
+---------------------------
 
 Using fewer unique materials is almost always better for performance. Combining materials which only differ in their texture allows them to benefit from static and dynamic batching. If you want you can manually create a texture atlas for your own meshes, but resizing requires updating all your mesh UVs, and is generally a hassle. Considering that most workshop maps use objects from a variety of different mod packs, atlas generation helps them all work together.
 
-## Materials eligible for atlas inclusion
+Materials eligible for atlas inclusion
+--------------------------------------
 
 Standard (Decalable) or Standard (Specular setup) (Decalable):
 
@@ -32,7 +36,8 @@ Custom/Card: supported for the automatically generated tree skybox models.
 
 Custom/Foliage: default trees/bushes.
 
-## Excluding specific objects and resources from batching
+Excluding specific objects and resources from batching
+------------------------------------------------------
 
 If you know your asset is incompatible you can add this line to the .dat file:
 
@@ -40,13 +45,15 @@ If you know your asset is incompatible you can add this line to the .dat file:
 
 NPCs, decals, and speedtrees (when enabled) are excluded by default. This option may be useful for elaborate setups using Unity Event components. For example if an event moves the renderer transform or sets material parameters.
 
-## Finding renderers that could benefit from atlas inclusion
+Finding renderers that could benefit from atlas inclusion
+---------------------------------------------------------
 
 By default the game considers every renderer in objects and resources. You can enable logging for why each renderer is excluded with the `-LogLevelBatchingTextureAtlasExclusions` launch option. Inclusion in the atlas is beneficial to merge as many meshes as possible into as few static batches as possible, but ineligible renderers will use static batching regardless.
 
 None of the messages logged are "errors" per se. It only explains why the game cannot (yet) atlas them. The most useful message for finding assets to modify is "Wrap Mode is not Clamp" because if the mesh does not require UVs outside the 0-1 square it can use `Clamp` wrap mode.
 
-## Validating UVs
+Validating UVs
+--------------
 
 When textures are merged into an atlas any meshes referencing them need their UV coordinates updated. If any UVs are outside the 0-1 square they will now be overlapping a completely different texture and appear incorrectly. You can use the `-ValidateLevelBatchingUVs` launch option to log any batched meshes with out-of-bounds UVs. For example this error with the vanilla chess board: 
 
@@ -54,7 +61,8 @@ When textures are merged into an atlas any meshes referencing them need their UV
 
 In the case of the chess board it was a mistake in the unwrapping which was then fixed, but in most cases this would suggest the mesh relies on `Wrap Mode` being `Repeat`.
 
-## Previewing renderers using atlas
+Previewing renderers using atlas
+--------------------------------
 
 You can visualize which renderers have been included in the texture atlas by loading singleplayer with the `-PreviewLevelBatchingTextureAtlas` launch option:
 

--- a/ManualObjectCulling.md
+++ b/ManualObjectCulling.md
@@ -1,4 +1,5 @@
-# Manual Object Culling
+Manual Object Culling
+=====================
 
 This article is intended for map developers and explains **Manual Object Culling** volumes.
 
@@ -8,7 +9,8 @@ Drawing fewer objects is usually better for performance. Culling volumes allow y
 
 This comes with an obvious downside: when zooming in on most buildings it is readily apparent that the furniture is missing. I experimented with some workarounds like enabling objects near the center of your view while zoomed, but it did not feel any better. In my opinion the performance trade-off is worth it. "Large" objects like shipping containers that have higher gameplay importance as cover are excluded by default, and most buildings have their culling volumes inset from the edges slightly so that objects in the windows are excluded.
 
-## Editing volumes
+Editing volumes
+---------------
 
 You can enable the **Preview Culling** checkbox to hide all objects inside culling volumes. This is useful to find any objects that are not included when they should be. For example, while working on this update I realized the volumes in the vanilla cargo ships did not extend low enough to catch some of the furniture in the crew quarters. 
 
@@ -16,7 +18,8 @@ Objects inside volumes are found when loading the level. While working in the ed
 
 Updating the culling volumes costs some performance, so a large number of small volumes may actually make performance worse. It is worth comparing though.
 
-## Excluding specific objects
+Excluding specific objects
+--------------------------
 
 If you know your asset should never be managed by culling volumes you can add this line to the .dat file:
 
@@ -24,7 +27,8 @@ If you know your asset should never be managed by culling volumes you can add th
 
 For example, the aerospace facility on Germany is excluded so that the manually placed culling volumes can hide large objects like shipping containers without accidentally hiding the giant structure. Note: volumes owned by objects automatically exclude their owner object.
 
-## Volumes owned by objects
+Volumes owned by objects
+------------------------
 
 Most vanilla buildings come with default culling volumes which are not selectable because they are not saved in the level. These are the precursor to the manually placeable culling volumes, and have been invisibly hiding objects since 2014! Part of the goal with the culling volumes was to finally make these viewable in the editor because they have caused a lot of confusion over the years, especially for modded objects created without knowing they were there.
 
@@ -38,6 +42,7 @@ This is an area for future improvement, so I would not necessary recommend for/a
 
 **LOD_Size_X, LOD_Size_Y, LOD_Size_Z** *float*: Offsets calculated volume size in Mesh mode. Many vanilla buildings with flat rooftops use a negative Z offset to exclude HVAC units placed on the roof.
 
-## Testing culling volume performance benefit
+Testing culling volume performance benefit
+------------------------------------------
 
 If you would like to check whether culling volumes are providing any benefit you can run the game with the `-DisableCullingVolumes` launch option. Dense areas like Seattle tend to have the most noticeable difference.

--- a/ModHooks.md
+++ b/ModHooks.md
@@ -1,6 +1,8 @@
-# Mod Hooks
+Mod Hooks
+=========
 
-## Overview
+Overview
+--------
 
 Script Components can be added to Game Objects in Unity and exported in Asset Bundles _IF_ they match a script in the base game code. These intentionally exportable scripts are referred to as __Mod Hooks__. They can be imported into a Unity project from the Project.unitypackage, and added to game objects inside the Unturned components menu. Each script makes several Events available which can drive other component properties like visibility or play an animation.
 
@@ -8,7 +10,8 @@ Each script documents its purpose and members within its *.cs file.
 
 Originally proposed and coined by VitaxaRusModding in this GitHub issue: [Link](https://github.com/SmartlyDressedGames/Unturned-3.x-Community/issues/435)
 
-## Event Listeners
+Event Listeners
+---------------
 
 ### Activation Event Hook
 
@@ -62,7 +65,8 @@ Events for day, night, full moon, and weather. These events are fired on server 
 
 Events for a specific custom [Weather Asset](WeatherAsset.md). Any map can have an unlimited number of weather types and weather listeners.
 
-## Event Instigators
+Event Instigators
+-----------------
 
 ### Client Text Chat Messenger
 
@@ -80,7 +84,8 @@ The `UnityEvents.Allow_Server_Messages` and/or `UnityEvents.Allow_Server_Command
 
 Allows Unity events to spawn effect assets. When the `AuthorityOnly` field is enabled only the server will spawn effects and replicate them to clients.
 
-## Misc
+Misc
+----
 
 ### Fall Damage Override
 

--- a/OpenMod.md
+++ b/OpenMod.md
@@ -1,26 +1,39 @@
-# OpenMod
+OpenMod
+=======
 
 [OpenMod](https://github.com/openmod/openmod) is a spiritual successor to [Rocket](Rocket.md) developed by one of Rocket's original maintainers. It has its own plugin framework, but supports compatibility with existing Rocket plugins by integrating with RocketMod and LDM.
 
-# Installation
-## Installing OpenMod Using the RocketMod Installer Plugin (recommended)
+Installation
+============
+
+Installing OpenMod Using the RocketMod Installer Plugin (recommended)
+---------------------------------------------------------------------
+
 1. Download the latest OpenMod Installer Plugin for RocketMod from [here](https://github.com/openmod/OpenMod.Installer.RocketMod/releases/latest).
 2. Move it to the `/Rocket/Plugins` folder and restart your server.
 3. Run `/openmod install` and follow the instructions.
 4. Done! Now you can [start installing plugins](https://openmod.github.io/openmod-docs/userdoc/concepts/plugins.html).
 
-## Installing OpenMod Manually
+Installing OpenMod Manually
+---------------------------
+
 1. Download the latest OpenMod.Unturned.Module-vX.X.X.zip from [here](https://github.com/openmod/OpenMod/releases/latest).
 2. Copy the "OpenMod.Unturned" folder into the "Modules" folder inside the Unturned installation directory.
 3. Start your server. The first start will take a while since OpenMod will download its core components.
 4. Done! Now you can [start installing plugins](https://openmod.github.io/openmod-docs/userdoc/concepts/plugins.html).
 
-# Plugins
+Plugins
+=======
+
 You can find open-source OpenMod plugins [here](http://openmod.github.io/openmod-plugins).
 
-## Resources
+Resources
+---------
+
 - [GitHub Repository](https://github.com/openmod/openmod)
 - [Documentation](https://openmod.github.io/openmod-docs/)
 
-## RocketMod Compatibility
+RocketMod Compatibility
+-----------------------
+
 OpenMod can be installed side-by-side with RocketMod, so you can use both RocketMod and OpenMod without any issue. OpenMod does not aim to replace RocketMod but to work with it together instead.

--- a/PhysicsMaterialAsset.md
+++ b/PhysicsMaterialAsset.md
@@ -1,4 +1,5 @@
-# Physics Material Asset
+Physics Material Assets
+=======================
 
 Work-in-progress feature to allow custom physics effects rather than hardcoding them.
 
@@ -8,7 +9,8 @@ The `PhysicsMaterialExtensionAsset` type can be used to insert custom properties
 
 This is an [Asset v2](AssetsV2.md) class.
 
-## Properties
+Properties
+----------
 
 `UnityName` *string* or `UnityNames` *string array*: names of Unity "physic" materials to associate with this asset. Not set by extension assets. Multiple names can be specified as an array because the old built-in physics materials had several variants for special cases that should now be handled by these assets.
 

--- a/Rocket.md
+++ b/Rocket.md
@@ -1,14 +1,17 @@
-# Rocket
+Rocket
+======
 
 SDG maintains a fork of **Rocket** called the Legally Distinct Missile (or LDM) after the resignation of its original community team. Using this fork is recommended because it preserves compatibility, and has fixes for important legacy Rocket issues like multithreading exceptions and teleportation exploits.
 
-## Installation
+Installation
+------------
 
 The dedicated server includes the latest version, so an external download is not necessary:
 1. Copy the Rocket.Unturned module from the game's Extras directory.
 2. Paste it into the game's Modules directory.
 
-## Resources
+Resources
+---------
 
 Browse the source code for the maintained version: [Legally Distinct Missile Repository](https://github.com/SmartlyDressedGames/Legally-Distinct-Missile)
 
@@ -18,7 +21,8 @@ Following closure of the original forum the recommended sites for developer disc
 
 The RocketMod organization on GitHub hosts several related archived projects: [RocketMod (Abandoned)](https://github.com/RocketMod)
 
-## History
+History
+-------
 
 On the 20th of December 2019 Sven Mawby "fr34kyn01535" and Enes Sadık Özbek "Trojaner" officially ceased maintenance of Rocket. They kindly released the source code under the MIT license. [Read their full farewell statement here.](https://github.com/RocketMod/Rocket/blob/master/Farewell.md)
 

--- a/RocketMod.md
+++ b/RocketMod.md
@@ -1,3 +1,4 @@
-# RocketMod
+RocketMod
+=========
 
 The contents of this article have been moved to: [Rocket.md](Rocket.md)

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -1,4 +1,5 @@
-# Server Hosting Rules
+Server Hosting Rules
+====================
 
 Servers that violate these rules may be temporarily or permanently banned. To report a server for rule violations, or appeal a moderation decision applied to your server, you may file a ticket with SDG Support:
 
@@ -7,19 +8,22 @@ Servers that violate these rules may be temporarily or permanently banned. To re
 
 [View Moderation List](https://smartlydressedgames.com/UnturnedHostBans/index.html)
 
-## Recent changes
+Recent changes
+--------------
 
 **2023-02-15 revisions:** Many of the rules have been revised to be clearer, with regards to what is (or isn't) currently allowed. "Consumable microtransaction" is better defined, there are a couple of new examples, and deceptive pricing has its own dedicated asection. The monetization filter section also includes more information about the filter, its purpose, and which of the four options (including a newer "Monetized" option) your server should use.
 
 **2022-10-16 clarification:** Selling *vanilla* cosmetics, such as those available from the Stockpile or Steam Community Market, is not allowed. When offering cosmetics as a server microtransaction, the server network should should own (or have licensed) the rights to that content. Servers should not sell cosmetic content that they do not own the right to, such as vanilla cosmetics (either official, or community-contributed).
 
-## Monetization Types
+Monetization Types
+------------------
 
 Warnings for breaking the monetization rules first began being sent out on May 28, 2021. The monetization rules have now been in full effect since June 11, 2021.
 
 Hosts are allowed to sell permanent benefits and monthly subscriptions. Consumable microtransactions are **not** allowed. A consumable microtransaction is anything that can be permanently consumed, lost, stolen, or destroyed. If it cannot be permanently lost, then it is not considered a consumable.
 
-## Examples
+Examples
+--------
 
 This section will provide *examples* of allowed/banned monetization options. It is not an exhaustive list of every possible monetization strategy.
 
@@ -41,7 +45,8 @@ This section will provide *examples* of allowed/banned monetization options. It 
 - Selling ranks, kits, unlocks, benefits, etc. which stack with themselves as a loophole.
 - Selling copies of **vanilla** cosmetics, such as those available on the Stockpile or Steam Community Market.
 
-## Monetization Filter
+Monetization Filter
+-------------------
 
 Players can filter the in-game server list by this field. It is not required to configure this field, but ideally it should be set to whichever value accurately describes your server's monetization practices. When configured, this field must be configured truthfully.
 
@@ -61,15 +66,18 @@ Servers that only offer microtransactions that do not provide a gameplay advanta
 
 Servers that offer *any* "pay-to-win" microtransactions (i.e., those that provide a gameplay advantage)—such as selling "kits" containing items or vehicles—should use the `Monetized` option.
 
-## Deceptive Pricing
+Deceptive Pricing
+-----------------
 
 Fictitious and deceptive pricing is not allowed. For example: lying that a discount is nearly expired, or pretending the price is discounted when it has never been at the listed full price. We would strongly advise following [Steam's discounting rules](https://partner.steamgames.com/doc/marketing/discounts) to help avoid breaking any real-world laws.
 
-## Online Conduct
+Online Conduct
+--------------
 
 Repeated offenders of [Steam's rules and guidelines](https://support.steampowered.com/kb_article.php?ref=4045-USHJ-3810) will be banned.
 
-## Workshop File Copyright Infringement
+Workshop File Copyright Infringement
+------------------------------------
 
 Mod authors can submit a notice of copyright infringement here: https://steamcommunity.com/dmca/create/
 

--- a/ServerUpdateNotifications.md
+++ b/ServerUpdateNotifications.md
@@ -1,11 +1,14 @@
-# Server Update Notifications
+Server Update Notifications
+===========================
 
 Change logs are available on the [Steam News Hub](https://store.steampowered.com/news/app/304930). For quick notifications with the game version number and Steam build ID consider one of the following:
 
-## Discord
+Discord
+-------
 
 Messages are posted to the #dedicated-server-updates text channel on the [Official Discord Server](https://discord.gg/unturned) via web hook. Each message has fields with the game version number and Steam build ID.
 
-## RSS
+RSS
+---
 
 Each release is posted to an RSS feed on the Smartly Dressed Games website, with the game version number and Steam build ID: https://smartlydressedgames.com/rss/unturned-steam-dedicated-server-updates.xml

--- a/SpawnAsset.md
+++ b/SpawnAsset.md
@@ -1,5 +1,5 @@
-Spawns
-======
+Spawn Assets
+============
 
 The spawn asset type represents the weighted chances of an individual item, vehicle, or animal spawning at an any given spawn point. Create custom spawn tables that can be used on custom, curated, and official maps.
 

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -1,34 +1,40 @@
-# Troubleshooting
+Troubleshooting
+===============
 
-## Menus are big and overlapping
+Menus are big and overlapping
+-----------------------------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > General
 3. Find the Launch Options field
 4. Type "-ui_scale 1" without quotes
 
-## Game window is too small
+Game window is too small
+------------------------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > General
 3. Find the Launch Options field
 4. Type "-width 1920 -height 1080" without quotes, replacing 1920x1080 with your monitor resolution
 
-## Force Fullscreen
+Force Fullscreen
+----------------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > General
 3. Find the Launch Options field
 4. Type "-screen-fullscreen" without quotes
 
-## Force OpenGL
+Force OpenGL
+------------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > General
 3. Find the Launch Options field
 4. Type "-force-glcore" without quotes
 
-## D3D11 Crash
+D3D11 Crash
+-----------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > Local Files > Browse...
@@ -37,24 +43,28 @@
 5. Add a line with "force-d3d11-bltblt-mode=" without quotes
 6. Save and close the file
 
-## Delete Items
+Delete Items
+------------
 
 1. Open the in-game Steam inventory from Menu > Survivors > Inventory
 2. Select any items you wish to remove and a Delete or Salvage button will show under the icon
 3. Confirm the deletion
 
-## Local Files
+Local Files
+-----------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > Local Files > Browse...
 
-## Verify
+Verify
+------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > Local Files
 3. Click "Verify integrity of game files..."
 
-## Windows Log Files
+Windows Log Files
+-----------------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > Local Files > Browse...
@@ -64,7 +74,8 @@
 6. Open the Unity AppData folder
 7. Attach the Player.log file to your email
 
-## Mac Log Files
+Mac Log Files
+-------------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > Local Files > Browse...
@@ -74,19 +85,22 @@
 6. Open the Logs folder > Smartly Dressed Games > Unturned
 7. Attach the Player.log file to your email
 
-## Linux Log Files
+Linux Log Files
+---------------
 
 1. Go to ~/.config/unity3d/Smartly Dressed Games/Unturned/Player.log
 2. Attach the Player.log file to your email
 
-## Unity Windows Crash Files
+Unity Windows Crash Files
+-------------------------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > Local Files > Browse...
 3. Open the "Unity Temp" folder
 4. Zip and attach the Crashes folder to your email
 
-## Repair BattlEye
+Repair BattlEye
+---------------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > Local Files > Browse...
@@ -97,23 +111,27 @@
 7. Select Properties... > Local Files
 8. Click "Verify integrity of game files..."
 
-## Opt-out of Betas
+Opt-out of Betas
+----------------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > Betas
 3. From the dropdown select "None"
 
-## Steam Cloud
+Steam Cloud
+-----------
 
 Your stored files can be found at:
 `C:\Program Files (x86)\Steam\userdata\ (your steam id) \304930`
 
-## View Workshop Files
+View Workshop Files
+-------------------
 
 This page lists your Steam account's Unturned file subscriptions:
 https://steamcommunity.com/my/myworkshopfiles/?appid=304930&browsefilter=mysubscriptions
 
-## Temporarily Disable All Workshop Files
+Temporarily Disable All Workshop Files
+--------------------------------------
 
 Disabling loading of your Steam account's Unturned file subscriptions can be helpful to narrow down whether a problem is mod-related or not.
 
@@ -122,21 +140,24 @@ Disabling loading of your Steam account's Unturned file subscriptions can be hel
 3. Find the Launch Options field
 4. Type "-NoWorkshopSubscriptions" without quotes
 
-## Force Disable Gold Upgrade
+Force Disable Gold Upgrade
+--------------------------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > General
 3. Find the Launch Options field
 4. Type "-NoGoldUpgrade" without quotes
 
-## Is it possible to unlock holiday achievements at other times of year?
+Is it possible to unlock holiday achievements at other times of year?
+---------------------------------------------------------------------
 
 1. Right-click Unturned in your Steam Library
 2. Select Properties... > General
 3. Find the Launch Options field
 4. Type "-Holiday=XMAS" without quotes
 
-## Refund Item Purchase
+Refund Item Purchase
+--------------------
 
 1. Open Steam
 2. Click your account name in the upper-right > Account details

--- a/Unity2018.md
+++ b/Unity2018.md
@@ -1,5 +1,5 @@
 Upgrading from Unity 2017 LTS to 2018 LTS
-=============================================
+=========================================
 
 Asset Bundles
 -------------
@@ -24,7 +24,7 @@ Workshop
 Uploads from 2018 LTS are incompatible with past versions of the game, and a warning message is shown when loading newer content in the 2017 LTS version.
 
 2017 LTS Availability
--------------------
+---------------------
 
 For archival purposes the 2017 LTS version of the game will remain in a "unity-2017" beta branch.
 

--- a/Unity2019.md
+++ b/Unity2019.md
@@ -1,5 +1,5 @@
 Upgrading from Unity 2018 LTS to 2019 LTS
-=============================================
+=========================================
 
 Blender Animations
 ------------------
@@ -7,6 +7,6 @@ Blender Animations
 Unity no longer supports importing multiple animations from a single .blend file. Exporting to an exchange format like .fbx is recommended instead, which is how the base game assets have always been handled. Note that this is recommended for meshes/models as well. [Read more details on the Unity issue tracker here.](https://issuetracker.unity3d.com/issues/using-multiple-animation-clips-in-blender-not-all-animation-clips-are-imported-using-a-blend-file)
 
 2018 LTS Availability
--------------------
+---------------------
 
 For archival purposes the 2018 LTS version of the game will remain in a "unity-2018" beta branch.

--- a/WeatherAsset.md
+++ b/WeatherAsset.md
@@ -1,4 +1,5 @@
-# Weather Asset
+Weather Asset
+=============
 
 Overrides the built-in snow and rain weather with custom events. This is feature is a work-in-progress.
 
@@ -6,13 +7,15 @@ Random weather can be scheduled to occur naturally on a map with the `Weather_Ty
 
 This is an [Asset v2](AssetsV2.md) class.
 
-## How to test?
+How to test?
+------------
 
 When a GUID is passed to the weather command it will start a custom weather event, and 0 can be used to end it.
 
 	/weather 819982d7a2b6453488a8c4c5d9efe67f
 
-## Properties Reference
+Properties Reference
+--------------------
 
 `Volume_Mask` [u32 Mask](Bitmask.md): only enabled while inside an ambience volume with non-zero bitwise AND result. Defaults to 0xFFFFFFFF.
 
@@ -54,7 +57,8 @@ When a GUID is passed to the weather command it will start a custom weather even
 
 `Max_Lightning_Interval` *float*: maximum seconds between lightning strikes.
 
-## Time of Day Properties
+Time of Day Properties
+----------------------
 
 Each of the four main times of day can override certain properties.
 
@@ -68,7 +72,8 @@ Each of the four main times of day can override certain properties.
 
 `Brightness_Multiplier` *float*: all ambient lighting colors are multiplied by this.
 
-## Effect Properties
+Effect Properties
+-----------------
 
 Multiple effects can be instantiated while the weather is active.
 
@@ -82,13 +87,15 @@ Multiple effects can be instantiated while the weather is active.
 
 `Rotate_Yaw_With_Wind` *bool*: should y-axis rotation match the wind direction? The built-in snow and rain rotate with wind.
 
-## Color Properties
+Color Properties
+----------------
 
 Each color can use a custom override, or a color from the level editor lighting panel. Using a level color is primarily for rain and snow backwards compatibility.
 
 `Level_Enum` *enum*: if set then the RGB specified are multiplied by this color.
 `R`, `G`, `B` *uint8*: color channel values.
 
-## NPC Conditions
+NPC Conditions
+--------------
 
 Global weather state and current weather intensity blend can be tested through NPC conditions. Refer to [Conditions.md](/NPCAsset/Conditions.md) for documentation.


### PR DESCRIPTION
Adjusts the markup for Lv1 and Lv2 headings so that – if we decide to use .rst instead of .md instead – most files will already be ready and functional. Also: this PR adds headings for any docs that didn't already have one.

None of the commits include markup that doesn't work with .md, so nothing will break.