### PR TITLE
Add notice/redirect to top of .MD files

### DIFF
--- a/AirdropAsset.md
+++ b/AirdropAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/airdrop-asset.html) instead.*
+
 Airdrop Asset
 =============
 

--- a/AnimalAsset.md
+++ b/AnimalAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/animal-asset.html) instead.*
+
 Animal Assets
 =============
 

--- a/Animation.md
+++ b/Animation.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/animation.html) instead.*
+
 Animation
 =========
 

--- a/AssetBundleCustomData.md
+++ b/AssetBundleCustomData.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/asset-bundle-custom-data.html) instead.*
+
 Asset Bundle Custom Data
 ========================
 

--- a/AssetBundles.md
+++ b/AssetBundles.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/asset-bundles.html) instead.*
+
 Asset Bundles
 =============
 

--- a/AssetPtr.md
+++ b/AssetPtr.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/data/asset-ptr.html) instead.*
+
 Asset Pointer
 =============
 

--- a/AssetValidation.md
+++ b/AssetValidation.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/asset-validation.html) instead.*
+
 Asset Validation
 ================
 

--- a/AssetsV1.md
+++ b/AssetsV1.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/assets-v1.html) instead.*
+
 Assets v1
 =========
 

--- a/AssetsV2.md
+++ b/AssetsV2.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/assets-v2.html) instead.*
+
 Assets v2
 =========
 

--- a/Bitmask.md
+++ b/Bitmask.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/data/bitmask.html) instead.*
+
 Bitmask
 =======
 

--- a/CharacterMeshReplacement.md
+++ b/CharacterMeshReplacement.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/character-mesh-replacement.html) instead.*
+
 Character Mesh Replacement
 ==========================
 

--- a/CommandIO.md
+++ b/CommandIO.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/servers/command-io.html) instead.*
+
 Command IO
 ==========
 

--- a/CommandLine.md
+++ b/CommandLine.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/about/command-line.html) instead.*
+
 Command-line arguments
 ======================
 

--- a/CraftingBlacklistAsset.md
+++ b/CraftingBlacklistAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/crafting-blacklist-asset.html) instead.*
+
 Crafting Blacklist Asset
 ========================
 

--- a/CuratedMaps.md
+++ b/CuratedMaps.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/mapping/curated-maps.html) instead.*
+
 Curated Maps
 ============
 

--- a/Currency.md
+++ b/Currency.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/currency-asset.html) instead.*
+
 Currency
 ========
 

--- a/DedicatedWorkshopUpdateMonitor.md
+++ b/DedicatedWorkshopUpdateMonitor.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/servers/dedicated-workshop-update-monitor.html) instead.*
+
 Dedicated Workshop Update Monitor
 =================================
 

--- a/EditorAssetRedirectors.md
+++ b/EditorAssetRedirectors.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/mapping/editor-asset-redirectors.html) instead.*
+
 Editor Asset Redirectors
 ========================
 

--- a/EffectAsset.md
+++ b/EffectAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/effect-asset.html) instead.*
+
 Effect Assets
 =============
 

--- a/FavoriteSearches.md
+++ b/FavoriteSearches.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/mapping/favorite-searches.html) instead.*
+
 Favorite Searches
 =================
 

--- a/Foliage.md
+++ b/Foliage.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/foliage-asset.html) instead.*
+
 Foliage
 =======
 

--- a/GUID.md
+++ b/GUID.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/data/guid.html) instead.*
+
 GUID
 ====
 

--- a/GameServerLoginTokens.md
+++ b/GameServerLoginTokens.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/servers/game-server-login-tokens.html) instead.*
+
 Game Server Login Tokens
 ========================
 

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/about/getting-started.html) instead.*
+
 Getting Started
 ===============
 

--- a/Glazier.md
+++ b/Glazier.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/servers/glazier.html) instead.*
+
 Glazier
 =======
 

--- a/ItemAsset/Actions.md
+++ b/ItemAsset/Actions.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/actions.html) instead.*
+
 Actions
 =======
 

--- a/ItemAsset/ArrestEndAsset.md
+++ b/ItemAsset/ArrestEndAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/arrest-end-asset.html) instead.*
+
 Arrest End Assets
 =================
 

--- a/ItemAsset/ArrestStartAsset.md
+++ b/ItemAsset/ArrestStartAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/arrest-start-asset.html) instead.*
+
 Arrest Start Assets
 ===================
 

--- a/ItemAsset/BackpackAsset.md
+++ b/ItemAsset/BackpackAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/backpack-asset.html) instead.*
+
 Backpack Assets
 ===============
 

--- a/ItemAsset/BagAsset.md
+++ b/ItemAsset/BagAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/bag-asset.html) instead.*
+
 Bag Assets
 ==========
 

--- a/ItemAsset/BarrelAsset.md
+++ b/ItemAsset/BarrelAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/barrel-asset.html) instead.*
+
 Barrel Assets
 =============
 

--- a/ItemAsset/BarricadeAsset.md
+++ b/ItemAsset/BarricadeAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/barricade-asset.html) instead.*
+
 Barricade Assets
 ================
 

--- a/ItemAsset/Blueprints.md
+++ b/ItemAsset/Blueprints.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/blueprints.html) instead.*
+
 Blueprints
 ==========
 

--- a/ItemAsset/BoxAsset.md
+++ b/ItemAsset/BoxAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/box-asset.html) instead.*
+
 Box Assets
 ==========
 

--- a/ItemAsset/CaliberAsset.md
+++ b/ItemAsset/CaliberAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/caliber-asset.html) instead.*
+
 Caliber Assets
 ==============
 

--- a/ItemAsset/ChargeAsset.md
+++ b/ItemAsset/ChargeAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/charge-asset.html) instead.*
+
 Charge Assets
 =============
 

--- a/ItemAsset/ClothingAsset.md
+++ b/ItemAsset/ClothingAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/clothing-asset.html) instead.*
+
 Clothing Assets
 ===============
 

--- a/ItemAsset/CloudAsset.md
+++ b/ItemAsset/CloudAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/cloud-asset.html) instead.*
+
 Cloud Assets
 ============
 

--- a/ItemAsset/ConsumeableAsset.md
+++ b/ItemAsset/ConsumeableAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/consumeable-asset.html) instead.*
+
 Consumeable Assets
 ==================
 

--- a/ItemAsset/DetonatorAsset.md
+++ b/ItemAsset/DetonatorAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/detonator-asset.html) instead.*
+
 Detonator Assets
 ================
 

--- a/ItemAsset/FarmAsset.md
+++ b/ItemAsset/FarmAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/farm-asset.html) instead.*
+
 Farm Assets
 ===========
 

--- a/ItemAsset/FilterAsset.md
+++ b/ItemAsset/FilterAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/filter-asset.html) instead.*
+
 Filter Assets
 =============
 

--- a/ItemAsset/FoodAsset.md
+++ b/ItemAsset/FoodAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/food-asset.html) instead.*
+
 Food Assets
 ===========
 

--- a/ItemAsset/FuelAsset.md
+++ b/ItemAsset/FuelAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/fuel-asset.html) instead.*
+
 Fuel Assets
 ===========
 

--- a/ItemAsset/GearAsset.md
+++ b/ItemAsset/GearAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/gear-asset.html) instead.*
+
 Gear Assets
 ===========
 

--- a/ItemAsset/GlassesAsset.md
+++ b/ItemAsset/GlassesAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/glasses-asset.html) instead.*
+
 Glasses Assets
 ==============
 

--- a/ItemAsset/GripAsset.md
+++ b/ItemAsset/GripAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/grip-asset.html) instead.*
+
 Grip Assets
 ===========
 

--- a/ItemAsset/GunAsset.md
+++ b/ItemAsset/GunAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/gun-asset.html) instead.*
+
 Gun Assets
 ==========
 

--- a/ItemAsset/HatAsset.md
+++ b/ItemAsset/HatAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/hat-asset.html) instead.*
+
 Hat Assets
 ==========
 

--- a/ItemAsset/KeyAsset.md
+++ b/ItemAsset/KeyAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/key-asset.html) instead.*
+
 Key Assets
 ==========
 

--- a/ItemAsset/MagazineAsset.md
+++ b/ItemAsset/MagazineAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/magazine-asset.html) instead.*
+
 Magazine Assets
 ===============
 

--- a/ItemAsset/MapAsset.md
+++ b/ItemAsset/MapAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/map-asset.html) instead.*
+
 Map Assets
 ==========
 

--- a/ItemAsset/MaskAsset.md
+++ b/ItemAsset/MaskAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/mask-asset.html) instead.*
+
 Mask Assets
 ===========
 

--- a/ItemAsset/MedicalAsset.md
+++ b/ItemAsset/MedicalAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/medical-asset.html) instead.*
+
 Medical Assets
 ==============
 

--- a/ItemAsset/OpticAsset.md
+++ b/ItemAsset/OpticAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/optic-asset.html) instead.*
+
 Optic Assets
 ============
 

--- a/ItemAsset/PantsAsset.md
+++ b/ItemAsset/PantsAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/pants-asset.html) instead.*
+
 Pants Assets
 ============
 

--- a/ItemAsset/PlaceableAsset.md
+++ b/ItemAsset/PlaceableAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/placeable-asset.html) instead.*
+
 Placeable Assets
 ================
 

--- a/ItemAsset/README.md
+++ b/ItemAsset/README.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/introduction.html) instead.*
+
 Item Assets
 ===========
 

--- a/ItemAsset/SentryAsset.md
+++ b/ItemAsset/SentryAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/sentry-asset.html) instead.*
+
 Sentry Assets
 =============
 

--- a/ItemAsset/ShirtAsset.md
+++ b/ItemAsset/ShirtAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/shirt-asset.html) instead.*
+
 Shirt Assets
 ============
 

--- a/ItemAsset/SightAsset.md
+++ b/ItemAsset/SightAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/sight-asset.html) instead.*
+
 Sight Assets
 ============
 

--- a/ItemAsset/StructureAsset.md
+++ b/ItemAsset/StructureAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/structure-asset.html) instead.*
+
 Structure Assets
 ================
 

--- a/ItemAsset/SupplyAsset.md
+++ b/ItemAsset/SupplyAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/supply-asset.html) instead.*
+
 Supply Assets
 =============
 

--- a/ItemAsset/TacticalAsset.md
+++ b/ItemAsset/TacticalAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/tactical-asset.html) instead.*
+
 Tactical Assets
 ===============
 

--- a/ItemAsset/ThrowableAsset.md
+++ b/ItemAsset/ThrowableAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/throwable-asset.html) instead.*
+
 Throwable Assets
 ================
 

--- a/ItemAsset/TrapAsset.md
+++ b/ItemAsset/TrapAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/trap-asset.html) instead.*
+
 Trap Assets
 ===========
 

--- a/ItemAsset/VestAsset.md
+++ b/ItemAsset/VestAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/vest-asset.html) instead.*
+
 Vest Assets
 ===========
 

--- a/ItemAsset/WaterAsset.md
+++ b/ItemAsset/WaterAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/water-asset.html) instead.*
+
 Water Assets
 ============
 

--- a/ItemAsset/WeaponAsset.md
+++ b/ItemAsset/WeaponAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-asset/weapon-asset.html) instead.*
+
 Weapon Assets
 =============
 

--- a/ItemData.md
+++ b/ItemData.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/item-data.html) instead.*
+
 Item Data (outdated)
 ====================
 

--- a/Landscape.md
+++ b/Landscape.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. It does not have a more up-to-date equivalent, because it regards a since-removed feature.*
+
 Landscape
 =========
 

--- a/Layers.md
+++ b/Layers.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/layers.html) instead.*
+
 Layers
 ======
 

--- a/LevelAsset.md
+++ b/LevelAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/level-asset.html) instead.*
+
 Level Asset
 ===========
 

--- a/LevelBatching.md
+++ b/LevelBatching.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/mapping/level-batching.html) instead.*
+
 Level Batching
 ==============
 

--- a/LevelConfig.md
+++ b/LevelConfig.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/mapping/level-config.html) instead.*
+
 Level Config
 ============
 

--- a/ManualObjectCulling.md
+++ b/ManualObjectCulling.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/mapping/manual-object-culling.html) instead.*
+
 Manual Object Culling
 =====================
 

--- a/MasterBundlePtr.md
+++ b/MasterBundlePtr.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/data/master-bundle-ptr.html) instead.*
+
 Master Bundle Pointer
 =====================
 

--- a/ModHooks.md
+++ b/ModHooks.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/mod-hooks.html) instead.*
+
 Mod Hooks
 =========
 

--- a/NPCAsset/Characters.md
+++ b/NPCAsset/Characters.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/npc-asset/npc-asset.html) instead.*
+
 NPC Character
 =============
 

--- a/NPCAsset/Conditions.md
+++ b/NPCAsset/Conditions.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/npc-asset/conditions.html) instead.*
+
 Conditions
 ==========
 

--- a/NPCAsset/Dialogues.md
+++ b/NPCAsset/Dialogues.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/npc-asset/dialogue-asset.html) instead.*
+
 Dialogue
 ========
 

--- a/NPCAsset/Quests.md
+++ b/NPCAsset/Quests.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/npc-asset/quest-asset.html) instead.*
+
 Quests
 ======
 

--- a/NPCAsset/README.md
+++ b/NPCAsset/README.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/npc-asset/introduction.html) instead.*
+
 NPCs
 ====
 

--- a/NPCAsset/Rewards.md
+++ b/NPCAsset/Rewards.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/npc-asset/rewards.html) instead.*
+
 Rewards
 =======
 

--- a/NPCAsset/Vendors.md
+++ b/NPCAsset/Vendors.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/npc-asset/vendor-asset.html) instead.*
+
 Vendors
 =======
 

--- a/OpenMod.md
+++ b/OpenMod.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/servers/openmod.html) instead.*
+
 OpenMod
 =======
 

--- a/PhysicsMaterialAsset.md
+++ b/PhysicsMaterialAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/physics-material-asset.html) instead.*
+
 Physics Material Assets
 =======================
 

--- a/PortForwarding.md
+++ b/PortForwarding.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/servers/port-forwarding.html) instead.*
+
 Port Forwarding
 ===============
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/index.html) instead.*
+
 Unturned Documentation
 ======================
 

--- a/Rocket.md
+++ b/Rocket.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/servers/rocket.html) instead.*
+
 Rocket
 ======
 

--- a/RocketMod.md
+++ b/RocketMod.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/servers/rocket.html) instead.*
+
 RocketMod
 =========
 

--- a/ServerHosting.md
+++ b/ServerHosting.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/servers/server-hosting.html) instead.*
+
 Server Hosting
 ==============
 

--- a/ServerHostingRules.md
+++ b/ServerHostingRules.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/servers/server-hosting-rules.html) instead.*
+
 Server Hosting Rules
 ====================
 

--- a/ServerUpdateNotifications.md
+++ b/ServerUpdateNotifications.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/servers/server-update-notifications.html) instead.*
+
 Server Update Notifications
 ===========================
 

--- a/SpawnAsset.md
+++ b/SpawnAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/spawn-asset.html) instead.*
+
 Spawn Assets
 ============
 

--- a/StereoSongAsset.md
+++ b/StereoSongAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/stereo-song-asset.html) instead.*
+
 Stereo Song Asset
 =================
 

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://support.smartlydressedgames.com/hc/en-us) instead.*
+
 Troubleshooting
 ===============
 

--- a/Unity2018.md
+++ b/Unity2018.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/unity-2018.html) instead.*
+
 Upgrading from Unity 2017 LTS to 2018 LTS
 =========================================
 

--- a/Unity2019.md
+++ b/Unity2019.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/unity-2019.html) instead.*
+
 Upgrading from Unity 2018 LTS to 2019 LTS
 =========================================
 

--- a/VehiclePhysicsProfile.md
+++ b/VehiclePhysicsProfile.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/vehicle-physics-profile-asset.html) instead.*
+
 Vehicle Physics Profile
 =======================
 

--- a/WeatherAsset.md
+++ b/WeatherAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/weather-asset.html) instead.*
+
 Weather Asset
 =============
 

--- a/ZombieDifficultyAsset.md
+++ b/ZombieDifficultyAsset.md
@@ -1,3 +1,7 @@
+**NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
+
+*This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/zombie-difficulty-asset.html) instead.*
+
 Zombie Difficulty Asset
 =======================
 


### PR DESCRIPTION
Notice includes links to their most relevant and up-to-date equivalents on stable (if it has an equivalent still). For example:

> **NOTICE:** *You are not reading the most up-to-date documentation. This file is old, and may not reflect the current modding or server capabilities. The latest documentation can be found at [Unturned Documentation](https://docs.smartlydressedgames.com/).*
>
> *This file may be removed in the future. Refer to its more [up-to-date equivalent](https://docs.smartlydressedgames.com/en/stable/assets/airdrop-asset.html) instead.*