### PR TITLE
Docs for ItemChargeAsset class

### DIFF
--- a/assets/item-asset/charge-asset.rst
+++ b/assets/item-asset/charge-asset.rst
@@ -23,24 +23,24 @@ Item Asset Properties
 Charge Asset Properties
 -----------------------
 
-**Animal_Damage** *float*: 
+**Animal_Damage** *float*: Damage dealt to animals caught within the area-of-effect explosion.
 
-**Barricade_Damage** *float*: 
+**Barricade_Damage** *float*: Damage dealt to barricades caught within the area-of-effect explosion.
 
 **Explosion_2** *uint16* or *GUID*: ID or GUID of effect to play upon detonation.
 
-**Explosion_Launch_Speed** *float*: 
+**Explosion_Launch_Speed** *float*: Launch speed of players caught within the area-of-effect explosion, in meters per second. Defaults to the value of ``Player_Damage * 0.1``.
 
-**Object_Damage** *float*: 
+**Object_Damage** *float*: Damage dealt to objects caught within the area-of-effect explosion. Defaults to the value of ``Resource_Damage``.
 
-**Player_Damage** *float*: 
+**Player_Damage** *float*: Damage dealt to players caught within the area-of-effect explosion.
 
-**Resource_Damage** *float*: 
+**Resource_Damage** *float*: Damage dealt to resources caught within the area-of-effect explosion.
 
-**Structure_Damage** *float*: 
+**Structure_Damage** *float*: Damage dealt to structures caught within the area-of-effect explosion.
 
-**Vehicle_Damage** *float*: 
+**Vehicle_Damage** *float*: Damage dealt to vehicles caught within the area-of-effect explosion.
 
-**Range2** *float*: 
+**Range2** *float*: Radius of the damaging, area-of-effect explosion.
 
-**Zombie_Damage** *float*: 
+**Zombie_Damage** *float*: Damage dealt to zombies caught within the area-of-effect explosion.

--- a/assets/item-asset/charge-asset.rst
+++ b/assets/item-asset/charge-asset.rst
@@ -3,6 +3,44 @@
 Charge Assets
 =============
 
-Noting this here for now, until charge properties are documented.
+Remote explosives can be placed and then remotely detonated with a :ref:`remote trigger <doc_item_asset_detonator>`.
+
+This inherits the :ref:`BarricadeAsset <doc_item_asset_barricade>` class.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+
+**Type** *enum* (``Charge``)
+
+**Useable** *enum* (``Barricade``)
+
+**Build** *enum* (``Charge``)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Charge Asset Properties
+-----------------------
+
+**Animal_Damage** *float*: 
+
+**Barricade_Damage** *float*: 
 
 **Explosion_2** *uint16* or *GUID*: ID or GUID of effect to play upon detonation.
+
+**Explosion_Launch_Speed** *float*: 
+
+**Object_Damage** *float*: 
+
+**Player_Damage** *float*: 
+
+**Resource_Damage** *float*: 
+
+**Structure_Damage** *float*: 
+
+**Vehicle_Damage** *float*: 
+
+**Range2** *float*: 
+
+**Zombie_Damage** *float*: 

--- a/assets/item-asset/detonator-asset.rst
+++ b/assets/item-asset/detonator-asset.rst
@@ -3,7 +3,7 @@
 Detonator Assets
 ================
 
-Remote triggers are inventory items that can be attached to ranged weapons.
+Remote triggers can be used to detonate :ref:`remote explosives <doc_item_asset_charge>`.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/assets/item-asset/magazine-asset.rst
+++ b/assets/item-asset/magazine-asset.rst
@@ -49,7 +49,7 @@ Magazine Asset Properties
 
 **Resource_Damage** *float*: Damage dealt to resources caught in the area-of-effect explosion.
 
-**Object_Damage** *float*: Damage dealt to zombies caught in the area-of-effect explosion. Defaults to the value used by Resource_Damage.
+**Object_Damage** *float*: Damage dealt to zombies caught in the area-of-effect explosion. Defaults to the value used by ``Resource_Damage``.
 
 **Explosion_Launch_Speed** *float*: Launch speed of players caught within the area-of-effect explosion, in meters per second. Defaults to the resulting value from ``Player_Damage * 0.1``. 
 

--- a/assets/item-asset/magazine-asset.rst
+++ b/assets/item-asset/magazine-asset.rst
@@ -51,7 +51,7 @@ Magazine Asset Properties
 
 **Object_Damage** *float*: Damage dealt to zombies caught in the area-of-effect explosion. Defaults to the value used by Resource_Damage.
 
-**Explosion_Launch_Speed** *float*: Launch speed of players caught within the area-of-effect explosion, in meters per second. Defaults to the resulting value from Player_Damage * 0.1. 
+**Explosion_Launch_Speed** *float*: Launch speed of players caught within the area-of-effect explosion, in meters per second. Defaults to the resulting value from ``Player_Damage * 0.1``. 
 
 **Explosion** *uint16* or *GUID*: ID or GUID of explosion effect. Defaults to 0.
 


### PR DESCRIPTION
- Lists and explains all properties for Charge assets.
- Fixes typo in Detonator asset docs.
- Adds inline code formatting to Magazine asset docs.