### PR TITLE
Markup property names as bolded/strong

### DIFF
--- a/assets/airdrop-asset.rst
+++ b/assets/airdrop-asset.rst
@@ -5,8 +5,8 @@ Airdrop Assets
 
 Overrides the care package model seen falling from the dropship, as well as the barricade spawned when it lands on the ground. Referenced by the :ref:`Level Asset <doc_assets_level>`.
 
-``Type`` *string*: ``SDG.Unturned.AirdropAsset``
+**Type** *string*: ``SDG.Unturned.AirdropAsset``
 
-``Landed_Barricade`` :ref:`Asset Pointer <doc_data_assetptr>`: Barricade item storage asset. Pivot point of the spawned barricade matches the pivot point of the care package as it hit the ground.
+**Landed_Barricade** :ref:`Asset Pointer <doc_data_assetptr>`: Barricade item storage asset. Pivot point of the spawned barricade matches the pivot point of the care package as it hit the ground.
 
-``Carepackage_Prefab`` :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: Model to spawn falling.
+**Carepackage_Prefab** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: Model to spawn falling.

--- a/assets/asset-definitions.rst
+++ b/assets/asset-definitions.rst
@@ -12,12 +12,12 @@ Header
 
 Each asset has a common ``GUID`` and ``Type`` header:
 
-``GUID`` :ref:`GUID <doc_data_guid>`: Unique ID used to link assets together. If left empty the game will prepend a newly generated GUID during startup.
+**GUID** :ref:`GUID <doc_data_guid>`: Unique ID used to link assets together. If left empty the game will prepend a newly generated GUID during startup.
 
-``Type`` *string*: Specific guides will list individual type names. This determines which keys the game will read. It can also be set to the fully qualified name of any class in any module.
+**Type** *string*: Specific guides will list individual type names. This determines which keys the game will read. It can also be set to the fully qualified name of any class in any module.
 
 .. note::
-
+	
 	``Type`` and ``GUID`` can either be specified in the root dictionary (default), or in a ``Metadata`` sub-dictionary. For example this is valid as well:
 
 	.. code-block:: text
@@ -27,7 +27,7 @@ Each asset has a common ``GUID`` and ``Type`` header:
 			GUID 7e4b847061b64272b42ea8869fd053c7
 			Type SDG.Unturned.Asset
 		}
-
+	
 	If ``GUID`` is specified in the ``Metadata`` sub-dictionary the game cannot (as of 2023-04-13) automatically prepend a newly generated one during startup.
 
 Body
@@ -35,12 +35,12 @@ Body
 
 The body contains any class properties. Individual asset type documentation elaborates on these.
 
-``ID`` *uint16*: 16-bit identifier. Unfortunately this ID must be unique within each category of assets (vehicles, items, animals, etc). Objects are the exception from this legacy restriction because they have been upgraded to fully use GUIDs.
+**ID** *uint16*: 16-bit identifier. Unfortunately this ID must be unique within each category of assets (vehicles, items, animals, etc). Objects are the exception from this legacy restriction because they have been upgraded to fully use GUIDs.
 
 Optionally the body properties can be placed into an ``Asset`` sub-dictionary. For example:
 
 .. code-block:: text
-
+	
 	GUID [...]
 	Type [...]
 	Asset
@@ -53,7 +53,7 @@ Optionally the body properties can be placed into an ``Asset`` sub-dictionary. F
 Is equivalent to:
 
 .. code-block:: text
-
+	
 	GUID [...]
 	Type [...]
 	ID [...]
@@ -65,13 +65,13 @@ Unity Asset Bundles
 
 Each Unturned asset is associated with a Unity asset bundle. If there is a master bundle in the file hierarchy that takes priority, otherwise a ``.unity3d`` bundle with the same name as the `.dat` file is used. There are several keys available to control the asset bundle:
 
-`Asset_Bundle_Version` *int*: Indicates which version of Unity this ``.unity3d`` bundle was built for. When Unturned upgrades Unity versions it tries to maintain backwards compatibility based on this number. 1 is Unity 5.5, 2 is 2017.4 LTS and 3 is 2018.4 LTS.
+**Asset_Bundle_Version** *int*: Indicates which version of Unity this ``.unity3d`` bundle was built for. When Unturned upgrades Unity versions it tries to maintain backwards compatibility based on this number. 1 is Unity 5.5, 2 is 2017.4 LTS and 3 is 2018.4 LTS.
 
-`Master_Bundle_Override` *string*: Name of a master bundle to use rather than the ``.unity3d`` bundle or master bundle found in the hierarchy.
+**Master_Bundle_Override** *string*: Name of a master bundle to use rather than the ``.unity3d`` bundle or master bundle found in the hierarchy.
 
-`Exclude_From_Master_Bundle` *string*: If this key exists the asset will look for a ``.unity3d`` bundle instead of the hierarchy.
+**Exclude_From_Master_Bundle** *string*: If this key exists the asset will look for a ``.unity3d`` bundle instead of the hierarchy.
 
-`Bundle_Override_Path` *string*: Path within the master bundle to load rather than this asset's file path.
+**Bundle_Override_Path** *string*: Path within the master bundle to load rather than this asset's file path.
 
 Localization
 ------------
@@ -83,7 +83,7 @@ Loading Order
 
 When scanning a folder for assets the game checks in this order:
 
-#. Is there a ``.asset`` file with the same name as the folder? e.g. Eaglefire.asset in the Eaglefire folder
-#. Is there a ``.dat`` file with the same name as the folder? e.g. Eaglefire.dat in the Eaglefire folder
-#. Is there an ``Asset.dat`` file?
-#. Otherwise, load all files with the ``.asset`` extension in the folder.
+1. Is there a ``.asset`` file with the same name as the folder? e.g. Eaglefire.asset in the Eaglefire folder
+2. Is there a ``.dat`` file with the same name as the folder? e.g. Eaglefire.dat in the Eaglefire folder
+3. Is there an ``Asset.dat`` file?
+4. Otherwise, load all files with the ``.asset`` extension in the folder.

--- a/assets/character-mesh-replacement.rst
+++ b/assets/character-mesh-replacement.rst
@@ -7,16 +7,17 @@ The player's character mesh can be entirely replaced with a special :ref:`shirt 
 
 Two limitations are that it must be a shirt because only shirts are loaded for first person (1P) views, and the 1P model should only contain the arms because the rest of the body is not animated.
 
-Asset properties:
+Properties Reference
+--------------------
 
-* Has_1P_Character_Mesh_Override: true
-* Character_Mesh_3P_Override_LODs: >0
-* Has_Character_Material_Override: true
-* Hair_Visible: true/false
-* Beard_Visible: true/false
+* **Has_1P_Character_Mesh_Override**: true
+* **Character_Mesh_3P_Override_LODs**: >0
+* **Has_Character_Material_Override**: true
+* **Hair_Visible**: true/false
+* **Beard_Visible**: true/false
 
-If Has_1P_Character_Mesh_Override is true then the game will try to load a prefab named "Character_Mesh_1P_Override_0". This should have a MeshFilter component with the first person arms replacement mesh.
+If ``Has_1P_Character_Mesh_Override`` is true then the game will try to load a prefab named "Character_Mesh_1P_Override_0". This should have a MeshFilter component with the first person arms replacement mesh.
 
-If Character_Mesh_3P_Override_LODs is greater than zero then the game will try to load prefabs for each LOD index (e.g., Character_Mesh_3P_Override_0). These should have MeshFilter components for the third person replacement meshes.
+If ``Character_Mesh_3P_Override_LODs`` is greater than zero then the game will try to load prefabs for each LOD index (e.g., Character_Mesh_3P_Override_0). These should have MeshFilter components for the third person replacement meshes.
 
-If Has_Character_Material_Override is true then the game will try to load a material named "Character_Material_Override" to replace the 1P and 3P mesh materials. Without this, equipped shirt and pants textures will be used by default.
+If ``Has_Character_Material_Override`` is true then the game will try to load a material named "Character_Material_Override" to replace the 1P and 3P mesh materials. Without this, equipped shirt and pants textures will be used by default.

--- a/assets/crafting-blacklist-asset.rst
+++ b/assets/crafting-blacklist-asset.rst
@@ -5,12 +5,12 @@ Crafting Blacklist Assets
 
 Prevents specific items or blueprints from being used while crafting. They are hidden from the item quick actions menu and recipe list.
 
-``Type`` *string*: ``SDG.Unturned.CraftingBlacklistAsset``
+**Type** *string*: ``SDG.Unturned.CraftingBlacklistAsset``
 
-``Input_Items`` array of Item :ref:`Asset Pointers <doc_data_assetptr>`: Any blueprints consuming these items are cannot be crafted.
+**Input_Items** array of Item :ref:`Asset Pointers <doc_data_assetptr>`: Any blueprints consuming these items are cannot be crafted.
 
 .. code-block:: cs
-
+	
 	"Input_Items"
 	[
 		"### this is a GUID number ###"
@@ -22,12 +22,12 @@ Prevents specific items or blueprints from being used while crafting. They are h
 		"### another GUID number ###"
 	]
 
-``Output_Items`` array of Item :ref:`Asset Pointers <doc_data_assetptr>`: Any blueprints generating these items cannot be crafted.
+**Output_Items** array of Item :ref:`Asset Pointers <doc_data_assetptr>`: Any blueprints generating these items cannot be crafted.
 
-``Blueprints`` array: Prevent specific individual blueprints from being crafted. Each entry has an ``Item`` :ref:`Asset Pointer <doc_data_assetptr>` and ``Blueprint`` index. For example to prevent the Chef Hat from being salvaged:
+**Blueprints** array: Prevent specific individual blueprints from being crafted. Each entry has an ``Item`` :ref:`Asset Pointer <doc_data_assetptr>` and ``Blueprint`` index. For example to prevent the Chef Hat from being salvaged:
 
 .. code-block:: cs
-
+	
 	"Blueprints"
 	[
 		{

--- a/assets/currency-asset.rst
+++ b/assets/currency-asset.rst
@@ -6,7 +6,7 @@ Currency Assets
 Any collection of items with different numeric values can be associated together in a **Currency** asset. NPCs can then automatically convert between the different items, and vendor menus can display information using the linked currency. This is intended to be useful beyond real-world currencies, e.g. bartering ammunition.
 
 .. figure:: img/VendorCurrency.jpg
-
+	
 	P.Riso's Hot Stuff vendor.
 
 Asset Setup
@@ -14,7 +14,7 @@ Asset Setup
 
 The currency asset defines how numbers are formatted, which items make up the currency, and their individual values. An example can be found at Bundles/Items/Supplies/CanadianCurrency.asset.
 
-``Type`` *string*: ``SDG.Unturned.CurrencyAsset``
+**Type** *string*: ``SDG.Unturned.CurrencyAsset``
 
 **ValueFormat** *string*: String to format numeric value into. For example "${0:N0} CAD" is the vanilla Canadian currency format.
 
@@ -23,7 +23,7 @@ The currency asset defines how numbers are formatted, which items make up the cu
 **Entries**: Array of items in the currency. Each has an **Item** GUID and **Value** integer. Optionally **Is_Visible_In_Vendor_Menu** bool can be false to hide the item from the NPC vendor currency list. For example these are the $10 and $20 notes in the Canadian currency:
 
 .. code-block:: cs
-
+	
 	{
 		"Item"
 		{
@@ -52,5 +52,5 @@ Testing
 The built-in "give" command accepts currency GUIDs as an alternative to item IDs. For example the following grants $1,000 CAD to the local player:
 
 .. code-block:: bash
-
+	
 	/give 5150ca8f765d4a68bfe54912146da410/1000

--- a/assets/foliage-asset.rst
+++ b/assets/foliage-asset.rst
@@ -11,27 +11,27 @@ There are sub-types of foliage asset for different uses, most notably instanced 
 FoliageResourceInfoAsset Properties Reference
 ---------------------------------------------
 
-``Type`` *string*: ``SDG.Unturned.FoliageResourceInfoAsset``
+**Type** *string*: ``SDG.Unturned.FoliageResourceInfoAsset``
 
-``Resource`` :ref:`Asset Pointer <doc_data_assetptr>`: actual tree to spawn.
+**Resource** :ref:`Asset Pointer <doc_data_assetptr>`: actual tree to spawn.
 
-``Obstruction_Radius`` *float*: spawn position is invalid if a sphere with this radius overlaps anything.
+**Obstruction_Radius** *float*: spawn position is invalid if a sphere with this radius overlaps anything.
 
-``Density`` *float*: this value is poorly named. One tree will try to spawn per this many square meters. For example a value of 4 will spawn approximately once per 2m x 2m area.
+**Density** *float*: this value is poorly named. One tree will try to spawn per this many square meters. For example a value of 4 will spawn approximately once per 2m x 2m area.
 
-``Min_Weight`` *float*: [0, 1] only spawn if landscape material weight is greater than this value.
+**Min_Weight** *float*: [0, 1] only spawn if landscape material weight is greater than this value.
 
-``Max_Weight`` *float*: [0, 1] only spawn if landscape material weight is less than this value.
+**Max_Weight** *float*: [0, 1] only spawn if landscape material weight is less than this value.
 
-``Min_Angle`` *float*: [0, 90] degrees only spawn if surface angle is greater than this value. For example a boulder only spawning on slopes steeper than 45 degrees.
+**Min_Angle** *float*: [0, 90] degrees only spawn if surface angle is greater than this value. For example a boulder only spawning on slopes steeper than 45 degrees.
 
-``Max_Angle`` *float*: [0, 90] degrees only spawn if surface angle is less than this value. For example a tree not growing on slopes steeper than 30 degrees.
+**Max_Angle** *float*: [0, 90] degrees only spawn if surface angle is less than this value. For example a tree not growing on slopes steeper than 30 degrees.
 
 Upgrade Devkit Foliage from V1 to V2
 ------------------------------------
 
 .. note::
-
+	
 	Maps with auto-converted terrain from the 3.22.8.0 update will have already been converted to V2.
 
 V1 of devkit foliage saved each small, individual region into their own files, which made maps slow to copy, download, and install. V2 fixes this by storing pointers for each region into a single file, at the cost of RAM in the map editor.

--- a/assets/layers.rst
+++ b/assets/layers.rst
@@ -10,38 +10,38 @@ Overview
 
 Built-in Layers
 
-- 0 Default
-- 1 TransparentFX
-- 2 Ignore Raycast
-- 4 Water: ocean and water tiles.
-- 5 UI: menus with :ref:`uGUI glazier <doc_glazier>` as well as plugin custom menus.
+- **0 Default**
+- **1 TransparentFX**
+- **2 Ignore Raycast**
+- **4 Water**: ocean and water tiles.
+- **5 UI**: menus with :ref:`uGUI glazier <doc_glazier>` as well as plugin custom menus.
 
 User Layers
 
-- 8 Logic: clickable overlays like the position, rotation and scale handles. Editor debug visuals that can be seen through walls are on this layer.
-- 9 Player: character capsule (not body hitboxes). Exists for all players server-side, but only the local player client-side.
-- 10 Enemy: player body hitboxes.
-- 11 Viewmodel: local first-person arms and weapon.
-- 12 Debris: typically small simulated objects like ragdolls, grenades, falling tree trunks, destroyed structures, and fragmented objects.
-- 13 Item: dropped interactable items.
-- 14 Resource: trees and boulders. Barricades attached to vehicles are moved to this layer.
-- 15 Large: large props placed in the level editor.
-- 16 Medium: medium props placed in the level editor.
-- 17 Small: small props without collision placed in the level editor.
-- 18 Sky: distant effects without collision like the clouds and stars.
-- 19 Environment: roads, grass and pebbles.
-- 20 Ground: landscape / terrain.
-- 21 Clip: invisible collision.
-- 22 Navmesh: invisible zombie-only collision. Navmesh graphs are generated from this collision, but the collision is also loaded on the server to help push zombies around.
-- 23 Entity: zombie and animal body hitboxes.
-- 24 Agent: zombie and animal character capsules (not body hitboxes).
-- 25 Ladder: invisible climbable trigger.
-- 26 Vehicle: all vehicle colliders.
-- 27 Barricade: barricade item placed in the world. Barricades attached to vehicles are moved to the Resource layer.
-- 28 Structure: structure item placed in the world.
-- 29 Tire: wheel colliders. Allows wheels to mask what they collide with.
-- 30 Trap: typically trigger colliders including rocket launcher projectiles and kill volumes.
-- 31 Ground2: no longer used after old maps were converted to terrain tiles. Previously this was for out-of-bounds terrain. Reserved for future use.
+- **8 Logic**: Clickable overlays like the position, rotation and scale handles. Editor debug visuals that can be seen through walls are on this layer.
+- **9 Player**: Character capsule (not body hitboxes). Exists for all players server-side, but only the local player client-side.
+- **10 Enemy**: Player body hitboxes.
+- **11 Viewmodel**: Local first-person arms and weapon.
+- **12 Debris**: Typically small simulated objects like ragdolls, grenades, falling tree trunks, destroyed structures, and fragmented objects.
+- **13 Item**: Dropped interactable items.
+- **14 Resource**: Trees and boulders. Barricades attached to vehicles are moved to this layer.
+- **15 Large**: Large props placed in the level editor.
+- **16 Medium**: Medium props placed in the level editor.
+- **17 Small**: Small props without collision placed in the level editor.
+- **18 Sky**: Distant effects without collision like the clouds and stars.
+- **19 Environment**: Roads, grass and pebbles.
+- **20 Ground**: Landscape / terrain.
+- **21 Clip**: Invisible collision.
+- **22 Navmesh**: Invisible zombie-only collision. Navmesh graphs are generated from this collision, but the collision is also loaded on the server to help push zombies around.
+- **23 Entity**: Zombie and animal body hitboxes.
+- **24 Agent**: Zombie and animal character capsules (not body hitboxes).
+- **25 Ladder**: Invisible climbable trigger.
+- **26 Vehicle**: All vehicle colliders.
+- **27 Barricade**: Barricade item placed in the world. Barricades attached to vehicles are moved to the Resource layer.
+- **28 Structure**: Structure item placed in the world.
+- **29 Tire**: Wheel colliders. Allows wheels to mask what they collide with.
+- **30 Trap**: Typically trigger colliders including rocket launcher projectiles and kill volumes.
+- **31 Ground2**: No longer used after old maps were converted to terrain tiles. Previously this was for out-of-bounds terrain. Reserved for future use.
 
 Layer Collision Matrix
 ----------------------
@@ -50,37 +50,37 @@ Note that these comments do **NOT** apply to collision queries like raycasts, sp
 
 No physics collision:
 
-- Default
-- TransparentFX
-- Ignore Raycast
-- Water
-- UI
-- Logic
-- Enemy
-- Viewmodel
-- Small
-- Sky
-- Environment
-- Ground
-- Entity
-- Ladder
-- Ground2
+- **Default**
+- **TransparentFX**
+- **Ignore Raycast**
+- **Water**
+- **UI**
+- **Logic**
+- **Enemy**
+- **Viewmodel**
+- **Small**
+- **Sky**
+- **Environment**
+- **Ground**
+- **Entity**
+- **Ladder**
+- **Ground2**
 
 Has physics collision:
 
-- Player: character controller layer is used by Unity as the underlying query mask.
-- Debris
-- Item
-- Resource
-- Large
-- Medium
-- Environment
-- Ground
-- Clip: collides with Player and Vehicle for its original purpose. Makeshift vehicles have invisible colliders on this layer to expand their simulation size without affecting barricade placement, so Clip also collides with some of the same layers as Vehicle.
-- Navmesh
-- Agent: character controller layer is used by Unity as the underlying query mask.
-- Vehicle
-- Barricade
-- Structure
-- Tire: wheel collider layer is used by Unity as the underlying query mask.
-- Trap
+- **Player**: Character controller layer is used by Unity as the underlying query mask.
+- **Debris**
+- **Item**
+- **Resource**
+- **Large**
+- **Medium**
+- **Environment**
+- **Ground**
+- **Clip**: Collides with Player and Vehicle for its original purpose. Makeshift vehicles have invisible colliders on this layer to expand their simulation size without affecting barricade placement, so Clip also collides with some of the same layers as Vehicle.
+- **Navmesh**
+- **Agent**: Character controller layer is used by Unity as the underlying query mask.
+- **Vehicle**
+- **Barricade**
+- **Structure**
+- **Tire**: Wheel collider layer is used by Unity as the underlying query mask.
+- **Trap**

--- a/assets/level-asset.rst
+++ b/assets/level-asset.rst
@@ -7,59 +7,59 @@ Each map can be associated with a **Level Asset**. These assets contain gameplay
 
 For examples check the ``Assets/Levels`` directory.
 
-``Type`` *string*: ``SDG.Unturned.LevelAsset``
+**Type** *string*: ``SDG.Unturned.LevelAsset``
 
-``Dropship`` :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: Overrides the model seen flying over the map when a care package is dropped.
+**Dropship** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: Overrides the model seen flying over the map when a care package is dropped.
 
-``Airdrop`` :ref:`Asset Pointer <doc_data_assetptr>`: Asset pointer to an :ref:`Airdrop Asset <doc_assets_airdrop>`. Overrides the falling care package model.
+**Airdrop** :ref:`Asset Pointer <doc_data_assetptr>`: Asset pointer to an :ref:`Airdrop Asset <doc_assets_airdrop>`. Overrides the falling care package model.
 
-``Crafting_Blacklists`` array of :ref:`Asset Pointers <doc_data_assetptr>`: Asset pointers to :ref:`Crafting Blacklist(s) <doc_assets_crafting_blacklist>`. Prevents specific items or blueprints from being used while crafting in the level.
+**Crafting_Blacklists** array of :ref:`Asset Pointers <doc_data_assetptr>`: Asset pointers to :ref:`Crafting Blacklist(s) <doc_assets_crafting_blacklist>`. Prevents specific items or blueprints from being used while crafting in the level.
 
-``Min_Stealth_Radius`` *float*: Player stealth skill level cannot reduce minimum detection distance below this value.
+**Min_Stealth_Radius** *float*: Player stealth skill level cannot reduce minimum detection distance below this value.
 
-``Weather_Types`` *array*: Determines which weather can occur naturally. Refer to schedulable weather properties. If weather is using legacy weather the default rain and snow will be included.
+**Weather_Types** *array*: Determines which weather can occur naturally. Refer to schedulable weather properties. If weather is using legacy weather the default rain and snow will be included.
 
-``Perpetual_Weather_Asset`` :ref:`Asset Pointer <doc_data_assetptr>`: Asset pointer to a :ref:`Weather Asset <doc_assets_weather>`. Overrides weather scheduling.
+**Perpetual_Weather_Asset** :ref:`Asset Pointer <doc_data_assetptr>`: Asset pointer to a :ref:`Weather Asset <doc_assets_weather>`. Overrides weather scheduling.
 
-``Global_Weather_Mask`` :ref:`u32 Mask <doc_data_bitmask>`: Fallback weather mask while player is not inside an ambience volume. Defaults to 0xFFFFFFFF.
+**Global_Weather_Mask** :ref:`u32 Mask <doc_data_bitmask>`: Fallback weather mask while player is not inside an ambience volume. Defaults to 0xFFFFFFFF.
 
-``Skills`` *array*: Overrides skill default and max levels. Refer to skill rule properties.
+**Skills** *array*: Overrides skill default and max levels. Refer to skill rule properties.
 
-``Enable_Admin_Faster_Salvage_Duration`` *bool*: By default, players in singleplayer and admins in multiplayer have a faster salvage time.
+**Enable_Admin_Faster_Salvage_Duration** *bool*: By default, players in singleplayer and admins in multiplayer have a faster salvage time.
 
-``Has_Clouds`` *bool*: Disables clouds in skybox when false. Defaults to true.
+**Has_Clouds** *bool*: Disables clouds in skybox when false. Defaults to true.
 
-``Loading_Screen_Music`` *array*: Randomly selected. Refer to music properties.
+**Loading_Screen_Music** *array*: Randomly selected. Refer to music properties.
 
-``Should_Animate_Background_Image`` *bool*: If true, the background image moves left/right with loading progress. Defaults to false because maps have important information on the loading screen.
+**Should_Animate_Background_Image** *bool*: If true, the background image moves left/right with loading progress. Defaults to false because maps have important information on the loading screen.
 
 Schedulable Weather Properties
 ------------------------------
 
-``Asset`` :ref:`Asset Pointer <doc_data_assetptr>`: Points to a :ref:`Weather Asset <doc_assets_weather>`.
+**Asset** :ref:`Asset Pointer <doc_data_assetptr>`: Points to a :ref:`Weather Asset <doc_assets_weather>`.
 
-``Min_Frequency`` *float*: When chosen to be the next scheduled weather event, minimum number of in-game days before it will start.
+**Min_Frequency** *float*: When chosen to be the next scheduled weather event, minimum number of in-game days before it will start.
 
-``Max_Frequency`` *float*: When chosen to be the next scheduled weather event, maximum number of in-game days before it will start.
+**Max_Frequency** *float*: When chosen to be the next scheduled weather event, maximum number of in-game days before it will start.
 
-``Min_Duration`` *float*: Minimum number of in-game days before the weather event will end.
+**Min_Duration** *float*: Minimum number of in-game days before the weather event will end.
 
-``Max_Duration`` *float*: Maximum number of in-game days before the weather event will end.
+**Max_Duration** *float*: Maximum number of in-game days before the weather event will end.
 
 Skill Rule Properties
 ---------------------
 
-``Id`` *string*: Name of skill, for example Sharpshooter.
+**Id** *string*: Name of skill, for example Sharpshooter.
 
-``Default_Level`` *int*: Skill level when player spawns. Note server config Spawn_With_Max_Skills takes priority.
+**Default_Level** *int*: Skill level when player spawns. Note server config Spawn_With_Max_Skills takes priority.
 
-``Max_Unlockable_Level`` *int*: Maximum skill level attainable through gameplay. Higher levels are hidden in the skills menu.
+**Max_Unlockable_Level** *int*: Maximum skill level attainable through gameplay. Higher levels are hidden in the skills menu.
 
-``Cost_Multiplier`` *float*: multiplier for XP upgrade cost.
+**Cost_Multiplier** *float*: multiplier for XP upgrade cost.
 
 Music Properties
 ----------------
 
-``Loop`` :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: looping audio clip played until loading finishes.
+**Loop** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: looping audio clip played until loading finishes.
 
-``Outro`` :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: audio clip played once loading finishes.
+**Outro** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: audio clip played once loading finishes.

--- a/assets/physics-material-asset.rst
+++ b/assets/physics-material-asset.rst
@@ -12,15 +12,15 @@ The ``PhysicsMaterialExtensionAsset`` type can be used to insert custom properti
 Properties
 ----------
 
-``Type`` *string*: ``SDG.Unturned.PhysicsMaterialAsset`` or ``SDG.Unturned.PhysicsMaterialExtensionAsset``
+**Type** *string*: ``SDG.Unturned.PhysicsMaterialAsset`` or ``SDG.Unturned.PhysicsMaterialExtensionAsset``
 
-``UnityName`` *string* or ``UnityNames`` *string array*: Names of Unity "physic" materials to associate with this asset. Not set by extension assets. Multiple names can be specified as an array because the old built-in physics materials had several variants for special cases that should now be handled by these assets.
+**UnityName** *string* or ``UnityNames`` *string array*: Names of Unity "physic" materials to associate with this asset. Not set by extension assets. Multiple names can be specified as an array because the old built-in physics materials had several variants for special cases that should now be handled by these assets.
 
-``Fallback`` :ref:`Asset Pointer <doc_data_assetptr>`: Points to a different physics material asset. Fallbacks are used when a property is not set. For example the snow physics material does not have a bullet casing bounce audio clip, so the gravel fallback is used instead.
+**Fallback** :ref:`Asset Pointer <doc_data_assetptr>`: Points to a different physics material asset. Fallbacks are used when a property is not set. For example the snow physics material does not have a bullet casing bounce audio clip, so the gravel fallback is used instead.
 
-``Base``  :ref:`Asset Pointer <doc_data_assetptr>`: Points to a physics material asset to extend. Properties from the extension asset will be appended to the base asset.
+**Base**  :ref:`Asset Pointer <doc_data_assetptr>`: Points to a physics material asset to extend. Properties from the extension asset will be appended to the base asset.
 
-``AudioDefs`` *dictionary*: pairs of key/name and :ref:`Master Bundle Pointer <doc_data_masterbundleptr>` to OneShotAudioDefinition. For example the ``ParticleSystemCollisionAudio`` component ``MaterialPropertyName`` is referring to these keys. Official properties include:
+**AudioDefs** *dictionary*: pairs of key/name and :ref:`Master Bundle Pointer <doc_data_masterbundleptr>` to OneShotAudioDefinition. For example the ``ParticleSystemCollisionAudio`` component ``MaterialPropertyName`` is referring to these keys. Official properties include:
 
 - BulletCasingBounce: used by vanilla non-shotgun particle collision audio.
 - BulletImpact: fired bullet hitting surface.
@@ -31,14 +31,14 @@ Properties
 - MeleeImpact: melee attack hitting surface.
 - ShotgunShellBounce: used by vanilla shotgun particle collision audio.
 
-``IsArable`` *bool*: If true, crops can be planted on this material.
+**IsArable** *bool*: If true, crops can be planted on this material.
 
-``HasOil`` *bool*: If true, oil drills can be placed on this material. Note at the time of writing (2022-02-10) oil drills can only be placed on terrain materials.
+**HasOil** *bool*: If true, oil drills can be placed on this material. Note at the time of writing (2022-02-10) oil drills can only be placed on terrain materials.
 
-``Character_Friction_Mode`` *enum* (``ImmediatelyResponsive``, ``Custom``): If custom the acceleration, deceleration, and max speed properties are used. Replacement for the hardcoded ice and slippery metal plate.
+**Character_Friction_Mode** *enum* (``ImmediatelyResponsive``, ``Custom``): If custom the acceleration, deceleration, and max speed properties are used. Replacement for the hardcoded ice and slippery metal plate.
 
-``Character_Acceleration_Multiplier`` *float*: Default acceleration is equal to the target move speed.
+**Character_Acceleration_Multiplier** *float*: Default acceleration is equal to the target move speed.
 
-``Character_Deceleration_Multiplier`` *float*: Default deceleration is 2m/s².
+**Character_Deceleration_Multiplier** *float*: Default deceleration is 2m/s².
 
 ``Character_Max_Speed_Multiplier`` *float*: Allows speed to reach up to this multiplied by the target move speed.

--- a/assets/stereo-song-asset.rst
+++ b/assets/stereo-song-asset.rst
@@ -8,32 +8,32 @@ Defines a music track that can be played on the in-game stereo item. (Or any cus
 Asset Properties Reference
 --------------------------
 
-``Type`` *string*: ``SDG.Unturned.StereoSongAsset``
+**Type** *string*: ``SDG.Unturned.StereoSongAsset``
 
-``Title`` string: display text to show in the music player menu. If a localization .dat file is present the ``Name`` key will be used, or a translation reference can be used. Examples:
+**Title** string: display text to show in the music player menu. If a localization .dat file is present the ``Name`` key will be used, or a translation reference can be used. Examples:
 
 .. code-block:: cs
-
+	
 	"Title" "My song"
 
 OR
 
-``Name`` in {Language}.dat file
+**Name** in {Language}.dat file
 
 OR
 
 .. code-block:: cs
-
+	
 	"Title"
 	{
 		"Namespace" "SDG"
 		"Token" "Stereo_Songs.Unturned_Theme.Title"
 	}
 
-``Song`` :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: audio clip to play. Can either be a newer master bundle pointer or an older content pointer. Examples:
+**Song** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: audio clip to play. Can either be a newer master bundle pointer or an older content pointer. Examples:
 
 .. code-block:: cs
-
+	
 	"Song"
 	{
 		"MasterBundle" "core.masterbundle"
@@ -43,13 +43,13 @@ OR
 OR
 
 .. code-block:: cs
-
+	
 	"Song"
 	{
 		"Name" "core.content"
 		"Path" "assets/resources/bundles/songs/unturned_theme.mp3"
 	}
 
-``Link_URL`` string: optional URL to open in web browser when external link button is clicked.
+**Link_URL** *string*: Optional URL to open in web browser when external link button is clicked.
 
-``Is_Loop`` *bool*: whether audio source should loop. Recommend **NOT** using .mp3 format for looping music.
+**Is_Loop** *bool*: Whether audio source should loop. Recommend **NOT** using .mp3 format for looping music.

--- a/assets/vehicle-physics-profile-asset.rst
+++ b/assets/vehicle-physics-profile-asset.rst
@@ -26,7 +26,7 @@ If a profile is not set, and the vehicle prefab's root rigidbody has a mass of 1
 Asset Properties Reference
 --------------------------
 
-``Type`` *string*: ``SDG.Unturned.VehiclePhysicsProfileAsset``
+**Type** *string*: ``SDG.Unturned.VehiclePhysicsProfileAsset``
 
 **Root_Mass**: If set, overrides vehicle rigidbody's mass.
 
@@ -52,15 +52,15 @@ Asset Properties Reference
 
 **Wheel_Friction_Sideways** and **Wheel_Friction_Forward**:
 
-* *Extremum_Slip*: If set, overrides friction curve extremum slip.
+* **Extremum_Slip**: If set, overrides friction curve extremum slip.
 
-* *Extremum_Value*: If set, overrides friction curve extremum value.
+* **Extremum_Value**: If set, overrides friction curve extremum value.
 
-* *Asymptote_Slip*: If set, overrides friction curve asymptote slip.
+* **Asymptote_Slip**: If set, overrides friction curve asymptote slip.
 
-* *Asymptote_Value*: If set, overrides friction curve asymptote value.
+* **Asymptote_Value**: If set, overrides friction curve asymptote value.
 
-* *Stiffness*: If set, overrides friction curve stiffness. Multiplies the extremum and asymptote values. Sideways default is 1.0 and forward default is 2.0.
+* **Stiffness**: If set, overrides friction curve stiffness. Multiplies the extremum and asymptote values. Sideways default is 1.0 and forward default is 2.0.
 
 **Motor_Torque_Multiplier**: Multiplies wheel collider motor torque which is usually driven by vehicle speed.
 

--- a/assets/weather-asset.rst
+++ b/assets/weather-asset.rst
@@ -13,91 +13,98 @@ How to test?
 When a GUID is passed to the weather command it will start a custom weather event, and 0 can be used to end it.
 
 .. code-block:: bash
-
+	
 	/weather 819982d7a2b6453488a8c4c5d9efe67f
 
 Properties Reference
 --------------------
 
-``Type`` *string*: ``SDG.Unturned.WeatherAsset``
+**Type** *string*: ``SDG.Unturned.WeatherAsset``
 
-``Volume_Mask`` :ref:`u32 Mask <doc_data_bitmask>`: only enabled while inside an ambience volume with non-zero bitwise AND result. Defaults to 0xFFFFFFFF.
+**Volume_Mask** :ref:`u32 Mask <doc_data_bitmask>`: Only enabled while inside an ambience volume with non-zero bitwise AND result. Defaults to 0xFFFFFFFF.
 
-``Fade_In_Duration`` *float*: seconds between weather event starting and reaching full intensity.
+**Fade_In_Duration** *float*: Seconds between weather event starting and reaching full intensity.
 
-``Fade_Out_Duration`` *float*: seconds between weather event ending and reaching zero intensity.
+**Fade_Out_Duration** *float*: Seconds between weather event ending and reaching zero intensity.
 
-``Ambient_Audio_Clip`` :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: audio clip to play globally. Volume matches intensity.
+**Ambient_Audio_Clip** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: Audio clip to play globally. Volume matches intensity.
 
-``Override_Fog`` *bool*: should fog configured in the lighting be overridden?
+**Override_Fog** *bool*: Should fog configured in the lighting be overridden?
 
-``Override_Atmospheric_Fog`` *bool*: should fog affect the skybox?
+**Override_Atmospheric_Fog** *bool*: Should fog affect the skybox?
 
-``Shadow_Strength_Multiplier`` *float*: directional light shadow strength multiplier.
+**Shadow_Strength_Multiplier** *float*: Directional light shadow strength multiplier.
 
-``Fog_Blend_Exponent`` *float*: power applied to fog blending alpha.
+**Fog_Blend_Exponent** *float*: Power applied to fog blending alpha.
 
-``Cloud_Blend_Exponent`` *float*: power applied to cloud blending alpha.
+**Cloud_Blend_Exponent** *float*: Power applied to cloud blending alpha.
 
-``Wind_Main`` *float*: wind zone windMain value. Will be replaced by more configurable game-specific wind eventually.
+**Wind_Main** *float*: Wind zone windMain value. Will be replaced by more configurable game-specific wind eventually.
 
-``Dawn``, ``Midday``, ``Dusk`` and ``Midnight``: refer to the Time of Day section.
+**Dawn**, **Midday**, **Dusk** and **Midnight**: Refer to the ":ref:`Time of Day <doc_assets_weather:time_of_day>`" section.
 
-``Effects`` *array*: refer to Effects section.
+**Effects** *array*: Refer to the ":ref:`Effects <doc_assets_weather:effects>`" section.
 
-``Stamina_Per_Second`` *float*: stamina +/- buff.
+**Stamina_Per_Second** *float*: Stamina +/- buff.
 
-``Health_Per_Second`` *float*: health +/- buff.
+**Health_Per_Second** *float*: Health +/- buff.
 
-``Food_Per_Second`` *float*: food +/- buff.
+**Food_Per_Second** *float*: Food +/- buff.
 
-``Water_Per_Second`` *float*: water +/- buff.
+**Water_Per_Second** *float*: Water +/- buff.
 
-``Virus_Per_Second`` *float*: virus +/- buff.
+**Virus_Per_Second** *float*: Virus +/- buff.
 
-``Has_Lightning`` *bool*: if true, lightning will be enabled for this weather type. In the future this should get cleaned up, but for now it is hardcoded for assigning a net id.
+**Has_Lightning** *bool*: If true, lightning will be enabled for this weather type. In the future this should get cleaned up, but for now it is hardcoded for assigning a net id.
 
-``Min_Lightning_Interval`` *float*: minimum seconds between lightning strikes.
+**Min_Lightning_Interval** *float*: Minimum seconds between lightning strikes.
 
-``Max_Lightning_Interval`` *float*: maximum seconds between lightning strikes.
+**Max_Lightning_Interval** *float*: Maximum seconds between lightning strikes.
+
+.. _doc_assets_weather:time_of_day:
 
 Time of Day Properties
 ----------------------
 
 Each of the four main times of day can override certain properties.
 
-``Fog_Color`` *struct*: distance-based fog. Optionally overrides the skybox color. Refer to Color section.
+**Fog_Color** *struct*: Distance-based fog. Optionally overrides the skybox color. Refer to the ":ref:`Color <doc_assets_weather:color>`" section.
 
-``Fog_Density`` *float*: [0, 1] similar to fog intensity in ambiance volume.
+**Fog_Density** *float*: Functions similarly to fog intensity in ambiance volume. Value must be within [0, 1].
 
-``Cloud_Color`` *struct*: inner body of cloud. Refer to Color section.
+**Cloud_Color** *struct*: Inner body of cloud. Refer to the ":ref:`Color <doc_assets_weather:color>`" section.
 
-``Cloud_Rim_Color`` *struct*: outer edge of cloud. More visible than inner color. Refer to Color section.
+**Cloud_Rim_Color** *struct*: Outer edge of cloud. More visible than inner color. Refer to the ":ref:`Color <doc_assets_weather:color>`" section.
 
-``Brightness_Multiplier`` *float*: all ambient lighting colors are multiplied by this.
+**Brightness_Multiplier** *float*: All ambient lighting colors are multiplied by this.
+
+.. _doc_assets_weather:effects:
 
 Effect Properties
 -----------------
 
 Multiple effects can be instantiated while the weather is active.
 
-``Prefab`` :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: game object with a particle system. PlayOnAwake should be disabled. For effects tied to the view it may be helpful to change the culling mode to Always Simulate.
+**Prefab** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: Game object with a particle system. PlayOnAwake should be disabled. For effects tied to the view it may be helpful to change the culling mode to "Always Simulate".
 
-``Emission_Exponent`` *float*: power applied to weather intensity multiplied by default constant rate over time.
+**Emission_Exponent** *float*: Power applied to weather intensity multiplied by default constant rate over time.
 
-``Pitch`` *float*: x-axis rotation when ``Rotate_Yaw_With_Wind`` is enabled.
+**Pitch** *float*: X-axis rotation when ``Rotate_Yaw_With_Wind`` is enabled.
 
-``Translate_With_View`` *bool*: should position in world-space match the camera? The built-in snow and rain move with the view. Position is zeroed when false. May be useful for transition effects like dust blowing into the map signaling the start of a sandstorm.
+**Translate_With_View** *bool*: Should position in world-space match the camera? The built-in snow and rain move with the view. Position is zeroed when false. May be useful for transition effects like dust blowing into the map signaling the start of a sandstorm.
 
-``Rotate_Yaw_With_Wind`` *bool*: should y-axis rotation match the wind direction? The built-in snow and rain rotate with wind.
+**Rotate_Yaw_With_Wind** *bool*: Should y-axis rotation match the wind direction? The built-in snow and rain rotate with wind.
+
+.. _doc_assets_weather:color:
 
 Color Properties
 ----------------
 
 Each color can use a custom override, or a color from the level editor lighting panel. Using a level color is primarily for rain and snow backwards compatibility.
 
-``Level_Enum`` *enum*: if set then the RGB specified are multiplied by this color.
-``R``, ``G``, ``B`` *uint8*: color channel values.
+**Level_Enum** *enum*: If set, then the RGB specified are multiplied by this color.
+
+**R**, **G**, **B** *uint8*: Color channel values.
 
 NPC Conditions
 --------------

--- a/assets/zombie-difficulty-asset.rst
+++ b/assets/zombie-difficulty-asset.rst
@@ -8,7 +8,7 @@ Override the difficulty settings for zombies in a navmesh. For reference, offici
 Properties Reference
 --------------------
 
-``Type`` *string*: ``SDG.Unturned.ZombieDifficultyAsset``
+**Type** *string*: ``SDG.Unturned.ZombieDifficultyAsset``
 
 **Overrides_Spawn_Chance** *bool*: Whether or not the spawn chance for zombies in the navmesh should be overridden by the values set in this asset. For example, it may be useful to set this to ``false`` if you *only* wanted to tweak properties not related to spawn chances, such as the damage thresholds for stuns. Defaults to true.
 


### PR DESCRIPTION
Replaces formatting of the property names (when they appear in the "list"-like format) with **strong** markup rather than ``inline code``. Also adds a couple new :ref: links to other sections when relevant.