### PR TITLE
Minor fixes/formatting + Color parsing

### DIFF
--- a/assets/data-file-format.rst
+++ b/assets/data-file-format.rst
@@ -42,7 +42,7 @@ For example: item assets check for the ``Pro`` flag marking them is a Steam econ
 Objects / Dictionaries
 ----------------------
 
-Each series of key-value pairs is a dictionary. (sometimes called an object) The top level of the file is treated as a dictionary, and child dictionaries can be added with ``{ }`` curly braces. Adding ``{`` on the line after a key opens a dictionary, and the matching ``}`` closes it.
+Each series of key-value pairs is a dictionary (sometimes called an object). The top level of the file is treated as a dictionary, and child dictionaries can be added with ``{ }`` curly braces. Adding ``{`` on the line after a key opens a dictionary, and the matching ``}`` closes it.
 
 In this example ``object1`` is a child dictionary in the root dictionary, and ``object2`` is a grand-child:
 
@@ -145,12 +145,12 @@ Certain older properties support the newer format while also supporting separate
 Color
 -----
 
-Colors can be parsed as a single hexidecimal value with optional '#' in front, or from a dictionary with R, G, and B keys.
+Colors can be parsed as a single hexidecimal value with optional "#" in front, or from a dictionary with R, G, and B keys.
 
 For example these are all valid colors:
 
 .. code-block:: text
-
+	
 	SkyColor 0000ff
 	GroundColor #00ff00
 	FogColor
@@ -160,9 +160,17 @@ For example these are all valid colors:
 		B 0
 	}
 
-Certain older properties support the newer format while also supporting separate _R, _G, and _B keys, namely: ``Nightvision_Color``.
+Certain older properties support the newer format while also supporting separate ``_R``, ``_G``, and ``_B`` keys, namely: ``Laser_Color``, and ``Nightvision_Color``.
+
+For example, this would be also be valid for any older property that supports the legacy format:
+
+.. code-block:: text
+	
+	Laser_Color_R 0.5
+	Laser_Color_G 1
+	Laser_Color_B 0
 
 History
 -------
 
-Prior to the 3.23.6.0 update there were two sets of custom Unturned syntax: "v1" for ``.dat`` files and "v2" for ``.asset`` files. v1 only supported key-value pairs, whereas v2 introduced dictionaries, lists, and required keys/values to be quoted. This is why ``{`` and ``[`` must be on a new line. (existing v1 assets may have ``{`` or ``[`` as the first character of a value)
+Prior to the 3.23.6.0 update there were two sets of custom Unturned syntax: "v1" for ``.dat`` files and "v2" for ``.asset`` files. v1 only supported key-value pairs, whereas v2 introduced dictionaries, lists, and required keys/values to be quoted. This is why ``{`` and ``[`` must be on a new line. (Existing v1 assets may have ``{`` or ``[`` as the first character of a value.)

--- a/assets/item-asset/barricade-asset.rst
+++ b/assets/item-asset/barricade-asset.rst
@@ -31,7 +31,7 @@ Barricade Asset Properties
 
 **Allow_Placement_On_Vehicle** *bool*: If true, this barricade can be placed on vehicles. Defaults to true, except when using ``Build Bed``, ``Build Sentry``, or ``Build Sentry_Freeform``.
 
-**Armor_Tier** *enum* (`Low`, `High`): Barricade armor can either be low-tier or high-tier. Defaults to low-tier, except when the barricade's name contains the word "Metal". By default, barricades with low-tier armor take 100% of the damage they receive, while barricades with high-tier armor take 50% of the damage they receive. These multipliers can be configured in the `gameplay config <https://wiki.smartlydressedgames.com/wiki/Gameplay_config>`_.
+**Armor_Tier** *enum* (``Low``, ``High``): Barricade armor can either be low-tier or high-tier. Defaults to low-tier, except when the barricade's name contains the word "Metal". By default, barricades with low-tier armor take 100% of the damage they receive, while barricades with high-tier armor take 50% of the damage they receive. These multipliers can be configured in the `gameplay config <https://wiki.smartlydressedgames.com/wiki/Gameplay_config>`_.
 
 **Bypass_Claim** *flag*: Can be placed inside someone else's claimed area.
 

--- a/assets/item-asset/glasses-asset.rst
+++ b/assets/item-asset/glasses-asset.rst
@@ -23,12 +23,8 @@ Glasses Asset Properties
 
 **Blindfold** *flag*: Specified if glasses should blacken the player's screen.
 
-**Nightvision_Color_B** *uint8*: The blue color component of an RGBA color, represented as a byte. Default value for Civilian is equivalent to 102. Default value for Military is 20. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
+**Nightvision_Color** :ref:`color <doc_data_file_format>`: Overrides the default color when using ``Vision Military``. When using the legacy color parsing, the ``_R``, ``_G``, and ``_B`` keys are unsigned bytes. The default value for ``Vision Civilian`` is equivalent to #666666. The default value for ``Vision Military`` is equivalent to #507814.
 
-**Nightvision_Color_G** *uint8*: The green color component of an RGBA color, represented as a byte. Default value for Civilian is equivalent to 102. Default value for Military is 120. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
+**Nightvision_Fog_Intensity** *float*: Intensity of fog while nightvision is active. Default value for ``Vision Civilian`` is 0.5. Default value for ``Vision Military`` is 0.25.
 
-**Nightvision_Color_R** *uint8*: The red color component of an RGBA color, represented as a byte. Default value for Civilian is equivalent to 102. Default value for Military is 80. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
-
-**Nightvision_Fog_Intensity** *float*: Intensity of fog while nightvision is active. Default value for Civilian is 0.5. Default value for Military is 0.25.
-
-**Vision** *enum* (``None``, ``Military``, ``Civilian``, ``Headlamp``): Type of unique lighting vision effect to use. Defaults to None. Use the Military enumerator when intending to assign a custom nightvision color via the color component properties.
+**Vision** *enum* (``None``, ``Military``, ``Civilian``, ``Headlamp``): Type of unique lighting vision effect to use. Defaults to "None". Use the "Military" enumerator when intending to assign a custom nightvision color via the color component properties.

--- a/assets/item-asset/shirt-asset.rst
+++ b/assets/item-asset/shirt-asset.rst
@@ -26,7 +26,7 @@ Shirt Asset Properties
 Body Mesh Replacements
 ----------------------
 
-For the full documentation, refer to the :ref:Character Mesh Replacement <doc_character_mesh_replacement>` documentation.
+For the full documentation, refer to the :ref:`Character Mesh Replacement <doc_character_mesh_replacement>` documentation.
 
 **Has_1P_Character_Mesh_Override** *bool*: A prefab named "Character_Mesh_1P_Override_0" should be loaded. Defaults to false.
 

--- a/assets/item-asset/sight-asset.rst
+++ b/assets/item-asset/sight-asset.rst
@@ -21,15 +21,15 @@ Sight Asset Properties
 
 **Holographic** *flag*: Specified if sight is holographic.
 
-**Nightvision_Color_B** *uint8*: The blue color component of an RGBA color, represented as a byte. Default value for Civilian is equivalent to 102. Default value for Military is 20. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
+**Nightvision_Color_B** *uint8*: The blue color component of an RGBA color, represented as a byte. Default value for ``Vision Civilian`` is equivalent to 102. Default value for Military is 20. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
 
-**Nightvision_Color_G** *uint8*: The green color component of an RGBA color, represented as a byte. Default value for Civilian is equivalent to 102. Default value for Military is 120. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
+**Nightvision_Color_G** *uint8*: The green color component of an RGBA color, represented as a byte. Default value for ``Vision Civilian`` is equivalent to 102. Default value for Military is 120. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
 
-**Nightvision_Color_R** *uint8*: The red color component of an RGBA color, represented as a byte. Default value for Civilian is equivalent to 102. Default value for Military is 80. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
+**Nightvision_Color_R** *uint8*: The red color component of an RGBA color, represented as a byte. Default value for ``Vision Civilian`` is equivalent to 102. Default value for Military is 80. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
 
-**Nightvision_Fog_Intensity** *float*: Intensity of fog while nightvision is active. Default value for Civilian is 0.5. Default value for Military is 0.25.
+**Nightvision_Fog_Intensity** *float*: Intensity of fog while nightvision is active. Default value for ``Vision Civilian`` is 0.5. Default value for Military is 0.25.
 
-**Vision** *enum* (``None``, ``Military``, ``Civilian``, ``Headlamp``): Type of unique lighting vision effect to use. Defaults to None. Use the Military enumerator when intending to assign a custom nightvision color via the color component properties.
+**Vision** *enum* (``None``, ``Military``, ``Civilian``, ``Headlamp``): Type of unique lighting vision effect to use. Defaults to "None". Use the "Military" enumerator when intending to assign a custom nightvision color via the color component properties.
 
 **Zoom** *float*: Multiplicative amount of zoom. Should be set to a value greater than 1. Defaults to 1.
 

--- a/assets/item-asset/tactical-asset.rst
+++ b/assets/item-asset/tactical-asset.rst
@@ -21,7 +21,7 @@ Tactical Asset Properties
 
 **Laser** *flag*: Provides a toggleable laser.
 
-**Laser_Color** *color*: Overrides default red color. Consists of **Laser_Color_R**, **Laser_Color_G**, **Laser_Color_B** *float* [0, 1].
+**Laser_Color** :ref:`color <doc_data_file_format>`: Overrides the default red color. When using the legacy color parsing, the ``_R``, ``_G``, and ``_B`` keys are floats within the range of [0, 1].
 
 **Light** *flag*: Provides a toggleable flashlight.
 

--- a/assets/item-asset/weapon-asset.rst
+++ b/assets/item-asset/weapon-asset.rst
@@ -39,13 +39,13 @@ Player Damage
 
 **Player_Damage_Bones** *enum* (``Always``, ``Heal``, ``None``): Determines the effect the weapon has in relation to the "Broken Bones" status effect. Defaults to the "None" enumerator.
 
-**Player_Damage_Food**: Amount of degradation dealt to a targeted player's food.
+**Player_Damage_Food** *float*: Amount of degradation dealt to a targeted player's food.
 
-**Player_Damage_Water**: Amount of degradation dealt to a targeted player's water.
+**Player_Damage_Water** *float*: Amount of degradation dealt to a targeted player's water.
 
-**Player_Damage_Virus**: Amount of degradation dealt to a targeted player's immunity.
+**Player_Damage_Virus** *float*: Amount of degradation dealt to a targeted player's immunity.
 
-**Player_Damage_Hallucination**: Length of hallucinations inflicted onto a targeted player, in seconds.
+**Player_Damage_Hallucination** *float*: Length of hallucinations inflicted onto a targeted player, in seconds.
 
 Zombie Damage
 `````````````

--- a/assets/npc-asset/conditions.rst
+++ b/assets/npc-asset/conditions.rst
@@ -214,7 +214,7 @@ Skillset
 
 **Condition\_#\_Type** *enum* (``Skillset``)
 
-**Condition\_#\_Value** *enum* (`Army`, `Camp`, `Chef`, `Farm`, `Fire`, `Fish`, `Medic`,	`None`, `Police`, `Thief`, `Work`): Target value, as the skillset.
+**Condition\_#\_Value** *enum* (``Army``, ``Camp``, ``Chef``, ``Farm``, ``Fire``, ``Fish``, ``Medic``, ``None``, ``Police``, ``Thief``, ``Work``): Target value, as the skillset. For example, this condition could be used to offer unique questlines, dialogue, or blueprints depending on the player's chosen skillset.
 
 World
 -----


### PR DESCRIPTION
- Minor fixes for typos/links, grammar, formatting inconsistencies, etc.
- Revises the explanations for the Nightvision_Color and Laser_Color properties due to the new color parsing.
- Include more examples regarding legacy color parsing on the data-file-format.rst doc.