### PR TITLE
Nightvision Scope properties

### DIFF
--- a/assets/item-asset/sight-asset.rst
+++ b/assets/item-asset/sight-asset.rst
@@ -21,15 +21,11 @@ Sight Asset Properties
 
 **Holographic** *flag*: Specified if sight is holographic.
 
-**Nightvision_Color_B** *uint8*: The blue color component of an RGBA color, represented as a byte. Default value for ``Vision Civilian`` is equivalent to 102. Default value for Military is 20. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
+**Nightvision_Color** :ref:`color <doc_data_file_format>`: Overrides the default color when using ``Vision Military``. When using the legacy color parsing, the ``_R``, ``_G``, and ``_B`` keys are unsigned bytes. The default value for ``Vision Civilian`` is equivalent to #666666. The default value for ``Vision Military`` is equivalent to #507814.
 
-**Nightvision_Color_G** *uint8*: The green color component of an RGBA color, represented as a byte. Default value for ``Vision Civilian`` is equivalent to 102. Default value for Military is 120. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
+**Nightvision_Fog_Intensity** *float*: Intensity of fog while nightvision is active. Default value for ``Vision Civilian`` is 0.5. Default value for ``Vision Military`` is 0.25.
 
-**Nightvision_Color_R** *uint8*: The red color component of an RGBA color, represented as a byte. Default value for ``Vision Civilian`` is equivalent to 102. Default value for Military is 80. Use with Vision Military and the other two color component properties to assign a custom nightvision color.
-
-**Nightvision_Fog_Intensity** *float*: Intensity of fog while nightvision is active. Default value for ``Vision Civilian`` is 0.5. Default value for Military is 0.25.
-
-**Vision** *enum* (``None``, ``Military``, ``Civilian``, ``Headlamp``): Type of unique lighting vision effect to use. Defaults to "None". Use the "Military" enumerator when intending to assign a custom nightvision color via the color component properties.
+**Vision** *enum* (``None``, ``Military``, ``Civilian``): Type of unique lighting vision effect to use. Defaults to "None". Use the "Military" enumerator when intending to assign a custom nightvision color via the color component properties.
 
 **Zoom** *float*: Multiplicative amount of zoom. Should be set to a value greater than 1. Defaults to 1.
 


### PR DESCRIPTION
Updated to match glasses documentation for NVGs. Removed mention of Vision Headlamp since this is unimplemented by sight assets