### PR TITLE
FuelAsset, RefillAsset, and TankAsset docs

### DIFF
--- a/assets/item-asset/charge-asset.rst
+++ b/assets/item-asset/charge-asset.rst
@@ -27,7 +27,7 @@ Charge Asset Properties
 
 **Barricade_Damage** *float*: Damage dealt to barricades caught within the area-of-effect explosion.
 
-**Explosion_2** *uint16* or *GUID*: ID or GUID of effect to play upon detonation.
+**Explosion2** *uint16* or *GUID*: ID or GUID of effect to play upon detonation.
 
 **Explosion_Launch_Speed** *float*: Launch speed of players caught within the area-of-effect explosion, in meters per second. Defaults to the value of ``Player_Damage * 0.1``.
 

--- a/assets/item-asset/farm-asset.rst
+++ b/assets/item-asset/farm-asset.rst
@@ -23,7 +23,7 @@ Item Asset Properties
 Farm Asset Properties
 ---------------------
 
-**Affected_By_Agriculture_Skill** *bool*: If true, the amount of crops acquired when harvesting the plant is affected by the `Agriculture skill <https://wiki.smartlydressedgames.com/wiki/Skills>`. Defaults to true.
+**Affected_By_Agriculture_Skill** *bool*: If true, the amount of crops acquired when harvesting the plant is affected by the `Agriculture skill <https://wiki.smartlydressedgames.com/wiki/Skills>`_. Defaults to true.
 
 **Allow_Fertilizer** *bool*: If true, allows the player to use fertilizer to fully grow the plant. Defaults to true.
 

--- a/assets/item-asset/fuel-asset.rst
+++ b/assets/item-asset/fuel-asset.rst
@@ -3,8 +3,26 @@
 Fuel Assets
 ===========
 
-Temporarily noting this here, until fuel assets are properly documented.
+Fuel canisters are useables able to siphon, store, and deposit fuel.
 
-**Delete_After_Filling_Target** *bool*: If true, item is removed from inventory after adding fuel to target.
+This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 
-**Always_Spawn_Full** *bool*: If true, the item will always spawn filled at full capacity.
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+
+**Type** *enum* (``Fuel``)
+
+**Useable** *enum* (``Fuel``)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Fuel Asset Properties
+---------------------
+
+**Always_Spawn_Full** *bool*: If true, this item will always spawn filled at full capacity.
+
+**Delete_After_Filling_Target** *bool*: If true, this item is removed from the player's inventory after adding fuel to target.
+
+**Fuel** *uint16*: Maximum units of fuel that can be stored in the fuel canister.

--- a/assets/item-asset/generator-asset.rst
+++ b/assets/item-asset/generator-asset.rst
@@ -3,7 +3,7 @@
 Generator Assets
 ================
 
-Generators are a placeable power sources.
+Generators are a placeable power sources. Players can deposit fuel into generators with a :ref:`fuel canister <doc_item_asset_fuel>`.
 
 This inherits the :ref:`BarricadeAsset <doc_item_asset_barricade>` class.
 

--- a/assets/item-asset/index.rst
+++ b/assets/item-asset/index.rst
@@ -45,12 +45,14 @@
 	optic-asset
 	pants-asset
 	placeable-asset
+	refill-asset
 	sentry-asset
 	shirt-asset
 	sight-asset
 	structure-asset
 	supply-asset
 	tactical-asset
+	tank-asset
 	throwable-asset
 	trap-asset
 	vest-asset

--- a/assets/item-asset/oil-pump-asset.rst
+++ b/assets/item-asset/oil-pump-asset.rst
@@ -23,4 +23,4 @@ Item Asset Properties
 Oil Pump Asset Properties
 -------------------------
 
-**Capacity** *uint16*: Maximum units of fuel that can be stored in the oil pump. Defaults to 0.
+**Fuel_Capacity** *uint16*: Maximum units of fuel that can be stored in the oil pump. Defaults to 0.

--- a/assets/item-asset/refill-asset.rst
+++ b/assets/item-asset/refill-asset.rst
@@ -3,7 +3,7 @@
 Refill Assets
 =============
 
-Refills (localized as "water canisters") are useables able to siphon, store, and deposit water. Players can also drink from water canisters in order to restore their status bars.
+Refills (localized as "water canisters") are useables able to siphon, store, and deposit water. Players can also drink from water canisters in order to restore their status bars. Water canisters have four potential states: empty, salty, dirty, or clean.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 
@@ -23,10 +23,40 @@ Refill Asset Properties
 
 **ConsumeAudioClip** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: AudioClip to play when the consumeable is used.
 
+**Clean_Food** *float*: Amount of food restored when drinking clean water.
+
+**Clean_Health** *float*: Amount of health restored when drinking clean water.
+
+**Clean_Oxygen** *float*: Amount of oxygen restored when drinking clean water.
+
+**Clean_Stamina** *float*: Amount of stamina restored when drinking clean water.
+
+**Clean_Virus** *float*: Amount of immunity depleted when drinking clean water.
+
+**Clean_Water** *float*: Amount of water restored when drinking clean water.
+
+**Dirty_Food** *float*: Amount of food restored when drinking dirty water. Defaults to the result of ``Clean_Food * 0.6``.
+
+**Dirty_Health** *float*: Amount of health restored when drinking dirty water. Defaults to the result of ``Clean_Health * 0.6``.
+
+**Dirty_Oxygen** *float*: Amount of oxygen restored when drinking dirty water. Defaults to the result of ``Clean_Oxygen * 0.6``.
+
+**Dirty_Stamina** *float*: Amount of stamina restored when drinking dirty water. Defaults to the result of ``Clean_Stamina * 0.6``.
+
+**Dirty_Virus** *float*: Amount of immunity depleted when drinking dirty water. Defaults to the result of ``Clean_Virus * -0.399999976``.
+
+**Dirty_Water** *float*: Amount of water restored when drinking dirty water. Defaults to the result of ``Clean_Water * 0.6``.
+
+**Salty_Food** *float*: Amount of food restored when drinking salty water. Defaults to the result of ``Clean_Food * 0.25``.
+
+**Salty_Health** *float*: Amount of health restored when drinking salty water. Defaults to the result of ``Clean_Health * 0.25``.
+
+**Salty_Oxygen** *float*: Amount of oxygen restored when drinking salty water. Defaults to the result of ``Clean_Oxygen * 0.25``.
+
+**Salty_Stamina** *float*: Amount of stamina restored when drinking salty water. Defaults to the result of ``Clean_Stamina * 0.25``.
+
+**Salty_Virus** *float*: Amount of immunity depleted when drinking salty water. Defaults to the result of ``Clean_Virus * -0.75``.
+
+**Salty_Water** *float*: Amount of water restored when drinking salty water. Defaults to the result of ``Clean_Water * 0.25``.
+
 .. deprecated:: 3.20.9.0 **Water** *byte*: Deprecated in favor of ``Clean_Water``. When this property is used, its value is assigned to ``Clean_Water`` instead.
-
-Clean_Health
-
-Salty_Health
-
-Dirty_Health

--- a/assets/item-asset/refill-asset.rst
+++ b/assets/item-asset/refill-asset.rst
@@ -1,0 +1,32 @@
+.. _doc_item_asset_refill:
+
+Refill Assets
+=============
+
+Refills (localized as "water canisters") are useables able to siphon, store, and deposit water. Players can also drink from water canisters in order to restore their status bars.
+
+This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+
+**Type** *enum* (``Refill``)
+
+**Useable** *enum* (``Refill``)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Refill Asset Properties
+-----------------------
+
+**ConsumeAudioClip** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: AudioClip to play when the consumeable is used.
+
+.. deprecated:: 3.20.9.0 **Water** *byte*: Deprecated in favor of ``Clean_Water``. When this property is used, its value is assigned to ``Clean_Water`` instead.
+
+Clean_Health
+
+Salty_Health
+
+Dirty_Health

--- a/assets/item-asset/tank-asset.rst
+++ b/assets/item-asset/tank-asset.rst
@@ -1,0 +1,28 @@
+.. _doc_item_asset_tank:
+
+Tank Assets
+===========
+
+Tanks (localized as "liquid storages") are placeables used to store water or fuel. Players can siphon from, or deposit into, a liquid storage with certain items. Fuel tanks require a :ref:`fuel canister <doc_item_asset_fuel>`, while water tanks require a :ref:`water canister <doc_item_asset_refill>`.
+
+This inherits the :ref:`BarricadeAsset <doc_item_asset_barricade>` class.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+
+**Type** *enum* (``Tank``)
+
+**Useable** *enum* (``Barricade``)
+
+**Build** *enum* (``Tank``)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Tank Asset Properties
+---------------------
+
+**Resource** *uint16*: Maximum units of liquid that can be stored in the tank. One unit of water is the equivalent of one usage of a water canister. Defaults to 0.
+
+**Source** *enum* (``Fuel``, ``None``, ``Water``): Type of liquid that can be stored in the tank.

--- a/assets/item-data.rst
+++ b/assets/item-data.rst
@@ -9,8 +9,6 @@ Item Data (outdated)
 	
 	This deprecated documentation file will be progressively phased out as the new documentation sources are expanded.
 
-----
-
 **Items** in *Unturned* encompass anything that can be carried in a player's in-game inventory. All items share some properties, while each item type has its own unique data.
 
 Non-specific Data
@@ -20,9 +18,9 @@ Non-specific Data
 
 **Durability**: Either a decimal probability chance of quality loss upon action, or guaranteed loss and durability value is instead representative of the amount lost.
 
-* *Canteens*: Guaranteed quality loss occurs upon drinking. Durability value represents the amount of quality loss.
-* *Melee Weapons*: Decimal probability chance of quality loss occurs upon hitting.
-* *Ranged Weapons*: Decimal probability chance of quality loss occurs upon shooting.
+- *Canteens*: Guaranteed quality loss occurs upon drinking. Durability value represents the amount of quality loss.
+- *Melee Weapons*: Decimal probability chance of quality loss occurs upon hitting.
+- *Ranged Weapons*: Decimal probability chance of quality loss occurs upon shooting.
 
 **Wear**: Increment to degrade quality by. Only applicable to items where durability represents a decimal probability chance of quality loss.
 
@@ -59,58 +57,6 @@ Item Storages
 
 **Should_Close_When_Outside_Range**: ``true``. Defaults to false. Only applicable to interactive barricades that generate a UI element, such as item storages and signs.
 
-Liquid Storages
-```````````````
-
-**Type**: ``Tank``
-
-**Useable**: ``Barricade``
-
-**Build**: ``Tank``
-
-**Source**: ``Fuel``, ``Water``
-
-**Resource**: Numerical maximum capacity of liquid units that can be stored. Water units are measured in potential drinking uses.
-
-Oil Pumps
-`````````
-
-**Type**: ``Oil_Pump``
-
-**Useable**: ``Barricade``
-
-**Build**: ``Oil``
-
-**Fuel_Capacity**: Numerical maximum capacity of fuel units able to be stored. 
-
-Plants
-``````
-
-**Type**: ``Farm``
-
-**Useable**: ``Barricade``
-
-**Build**: ``Farm``
-
-**Growth**: Number of seconds required to fully grow.
-
-**Grow**: ID of the item generated when harvesting a fully grown plant.
-
-Remote Explosives
-`````````````````
-
-**Type**: ``Charge``
-
-**Useable**: ``Barricade``
-
-**Build**: ``Charge``
-
-**Range2**: Meter radius of range for explosive damage.
-
-**Explosion2**: Explosion effect ID for the damaging explosion.
-
-Limb-independent entity damage is also applicable.
-
 Robotic Turrets
 ```````````````
 
@@ -132,23 +78,6 @@ Robotic Turrets
 
 **Infinite_Quality**: Weapon quality never depletes.
 
-Traps
-`````
-
-**Type**: ``Trap``
-
-**Useable**: ``Barricade``
-
-**Build**: ``Spike``, ``Wire``
-
-**Damage_Tires**: Specified if tires can be popped when ran over by a vehicle.
-
-**Range2**: Meter radius of range for explosive damage.
-
-**Explosion2**: Explosion effect ID for the damaging explosion.
-
-Limb-independent entity damage (e.g., Player_Damage) is also applicable.
-
 Fishing Poles
 -------------
 
@@ -157,22 +86,6 @@ Fishing Poles
 **Useable**: ``Fisher``
 
 **Reward_ID**: ID of the spawn table to pull catchable items from.
-
-Fuel Canisters
---------------
-
-**Type**: ``Fuel``
-
-**Useable**: ``Fuel``
-
-**Fuel**: Amount of fuel units added to target.
-
-Growth Supplements
-------------------
-
-**Type**: ``Grower``
-
-**Useable**: ``Grower``
 
 Structures
 ----------
@@ -240,12 +153,3 @@ When initiating voice chat with a walkie-talkie held, voice is transmitted throu
 **Type**: ``Tool``
 
 **Useable**: ``Walkie_Talkie``
-
-Water Canisters
----------------
-
-**Type**: ``Refill``
-
-**Useable**: ``Refill``
-
-**Water**: The number of water to restore.


### PR DESCRIPTION
Adds/finishes documentation for fuel canisters, water canisters, and liquid storages.
Updates TOC, fixes a couple property names, & removes outdated info from ItemData.rst file.