### PR TITLE
Fisher Asset docs

### DIFF
--- a/assets/item-asset/fisher-asset.rst
+++ b/assets/item-asset/fisher-asset.rst
@@ -1,0 +1,24 @@
+.. _doc_item_asset_fisher:
+
+Fisher Assets
+=============
+
+Fishers (localized as "fishing poles") are useables that allow for catching fish.
+
+This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+
+**Type** *enum* (``Fisher``)
+
+**Useable** *enum* (``Fisher``)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Fisher Asset Properties
+-----------------------
+
+**Reward_ID** *uint16*: Legacy ID of the spawn table a reward should be generated from upon successfully catching something with the fishing pole.

--- a/assets/item-asset/index.rst
+++ b/assets/item-asset/index.rst
@@ -26,6 +26,7 @@
 	detonator-asset
 	farm-asset
 	filter-asset
+	fisher-asset
 	food-asset
 	fuel-asset
 	gear-asset


### PR DESCRIPTION
Adds the new doc to the TOC/index as well.

Tangential comments, but I noticed that:
- The 3 audio clips (_Cast_, _Reel_, and _Tug_) aren't redirectable from the .dat file.
- `Reward_ID` only supports legacy IDs (no GUID support for the spawn table).