### PR TITLE
Update getting-started.rst - Unity Version Number

### DIFF
--- a/about/getting-started.rst
+++ b/about/getting-started.rst
@@ -3,7 +3,7 @@
 Getting Started
 ===============
 
-Installing the Unity Editor is required for exporting custom content into the game. Any 2019.4 LTS version should be compatible. `View Download Links <https://unity3d.com/unity/qa/lts-releases?version=2019.4>`_
+Installing the Unity Editor is required for exporting custom content into the game. Most 2020.3 LTS version should be compatible; Unturned currently uses 2020.3.38f1. `View Download Links <https://unity3d.com/unity/qa/lts-releases?version=2020.3>`_
 
 Once Unity is installed a project can be created to house custom content. At this point it is recommended to import Unturned's provided source packages:
 


### PR DESCRIPTION
Previously stated that 2019.4 LTS versions would be compatible for modding. While this may be possible, it's not guarantied. More minorly, not all LTS version will work. Bundles created on 2020.3.47 currently fail and the game fails to load assets.