### PR TITLE
Tool, Vehicle Repair Tool, and Tire asset docs

### DIFF
--- a/assets/item-asset/index.rst
+++ b/assets/item-asset/index.rst
@@ -55,7 +55,10 @@
 	tactical-asset
 	tank-asset
 	throwable-asset
+	tire-asset
+	tool-asset
 	trap-asset
+	vehicle-repair-tool-asset
 	vest-asset
 	water-asset
 	weapon-asset

--- a/assets/item-asset/tire-asset.rst
+++ b/assets/item-asset/tire-asset.rst
@@ -1,0 +1,24 @@
+.. _doc_item_asset_tire:
+
+Tire Assets
+===========
+
+Tires (localized as "tools") are useables that allow for adding and removing tires from vehicles.
+
+This inherits the :ref:`VehicleRepairToolAsset <doc_item_asset_vehicle_repair_tool>` class.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+
+**Type** *enum* (``Tire``)
+
+**Useable** *enum* (``Tire``)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Tire Asset Properties
+---------------------
+
+**Mode** *enum* (``Add``, ``Remove``): How the usable should interact with tires. ``Mode Add`` will consume the item to add a tire to the vehicle. ``Mode Remove`` allows the usable to remove tires, adding the corresponding item to the player's inventory.

--- a/assets/item-asset/tool-asset.rst
+++ b/assets/item-asset/tool-asset.rst
@@ -1,0 +1,24 @@
+.. _doc_item_asset_tool:
+
+Tool Assets
+===========
+
+Tools are a type of useable. The specific function of a tool significantly depends on the ``Useable`` property.
+
+This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+
+**Type** *enum* (``Tool``): When intending to use a child class, refer to that class's documentation instead for the proper enumerator to use.
+
+**Useable** *enum* (``Carjack``, ``Carlockpick``, ``Housing_Planner``, ``Walkie_Talkie``): When using the ``Carjack`` enumerator, the tool can be used on vehicles to launch them upwards into the air. When using ``Carlockpick``, the tool can be used once on any locked vehicle in order to forcefully unlock it. When using ``Housing_Planner``, the tool can be used to quickly access :ref:`structure pieces <doc_item_asset_structure>` from the player's own inventory. When using ``Walkie_Talkie``, the tool can be used to have long-distance voice chat communications with other players.
+
+**ID** *uint16*: Must be a unique identifier.
+
+Tool Asset Properties
+---------------------
+
+Tools have no unique asset properties. Instead, refer to ``Useable`` for relevant configuration options. Refer to parent classes for additional properties.

--- a/assets/item-asset/vehicle-repair-tool-asset.rst
+++ b/assets/item-asset/vehicle-repair-tool-asset.rst
@@ -1,0 +1,24 @@
+.. _doc_item_asset_vehicle_repair_tool:
+
+Vehicle Repair Tool Assets
+==========================
+
+Vehicle repair tools (localized as "tools") are useables for replacing vehicle batteries.
+
+This inherits the :ref:`ToolAsset <doc_item_asset_tool>` class.
+
+Item Asset Properties
+---------------------
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+
+**Type** *enum* (``Vehicle_Repair_Tool``)
+
+**Useable** *enum* (``Battery_Vehicle``)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Vehicle Repair Tool Asset Properties
+------------------------------------
+
+Vehicle repair tools have no unique asset properties. Refer to parent classes for additional properties.

--- a/assets/item-data.rst
+++ b/assets/item-data.rst
@@ -38,8 +38,6 @@ See :ref:`Asset Bundles <doc_asset_bundles>` for full documentation regarding as
 Barricades
 ----------
 
-**Build**: ``Barrel_Rain``, ``Bed``, ``Cage``, ``Campfire``, ``Claim``, ``Clock``, ``Door``, ``Fortification``, ``Freeform``, ``Gate``, ``Glass``, ``Hatch``, ``Ladder``, ``Mannequin``, ``Note``, ``Oven``, ``Oxygenator``, ``Safezone``, ``Shutter``, ``Sign``, ``Sign_Wall``, ``Spot``, ``Stereo``, ``Torch``, ``Vehicle``
-
 Item Storages
 `````````````
 
@@ -77,15 +75,6 @@ Robotic Turrets
 **Infinite_Ammo**: ammunition never depletes.
 
 **Infinite_Quality**: Weapon quality never depletes.
-
-Fishing Poles
--------------
-
-**Type**: ``Fisher``
-
-**Useable**: ``Fisher``
-
-**Reward_ID**: ID of the spawn table to pull catchable items from.
 
 Structures
 ----------


### PR DESCRIPTION
Create docs for the tool, vehicle repair tool, and tire assets (item types).  Removes a little bit of old info from the "deprecated" item-data file.