### PR TITLE
PlayerSpotLightConfig properties and ENPCHoliday

### DIFF
--- a/assets/item-asset/glasses-asset.rst
+++ b/assets/item-asset/glasses-asset.rst
@@ -27,17 +27,4 @@ Glasses Asset Properties
 
 **Nightvision_Fog_Intensity** *float*: Intensity of fog while nightvision is active. Default value for ``Vision Civilian`` is 0.5. Default value for ``Vision Military`` is 0.25.
 
-**Vision** *enum* (``None``, ``Military``, ``Civilian``, ``Headlamp``): Type of unique lighting vision effect to use. Defaults to "None", which has no vision effect. Use the "Military" enumerator to use its default nightvision configuration, or when intending to assign a custom nightvision color via the color component properties. Use "Civilian" to use its default nightvision configuration. Use "Headlamp" to enable a toggleable light source, and enable the default configuration of SpotLight dictionary.
-
-SpotLight Dictionary
-````````````````````
-
-**SpotLight_Enabled** *bool*: When true, this item should have a toggleable light source. Defaults to true.
-
-**SpotLight_Range** *float*: Range of the light source's beam, in meters. Defaults to 64.
-
-**SpotLight_Angle** *float*: Angle of the light source's beam in degrees. Defaults to 90.
-
-**SpotLight_Intensity** *float*: Intensity of the light source's beam. Defaults to 1.3.
-
-**SpotLight_Color** :ref:`color <doc_data_file_format>`: Color of the light source's beam. Defaults to #f5df93.
+**Vision** *enum* (``None``, ``Military``, ``Civilian``, ``Headlamp``): Type of unique lighting vision effect to use. Defaults to "None", which has no vision effect. Use the "Military" enumerator to use its default nightvision configuration, or when intending to assign a custom nightvision color via the color component properties. Use "Civilian" to use its default nightvision configuration. Use "Headlamp" to enable a toggleable light source, and allows for using :ref:`PlayerSpotLightConfig <doc_data_playerspotlightconfig>` properties.

--- a/assets/item-asset/glasses-asset.rst
+++ b/assets/item-asset/glasses-asset.rst
@@ -27,4 +27,17 @@ Glasses Asset Properties
 
 **Nightvision_Fog_Intensity** *float*: Intensity of fog while nightvision is active. Default value for ``Vision Civilian`` is 0.5. Default value for ``Vision Military`` is 0.25.
 
-**Vision** *enum* (``None``, ``Military``, ``Civilian``, ``Headlamp``): Type of unique lighting vision effect to use. Defaults to "None". Use the "Military" enumerator when intending to assign a custom nightvision color via the color component properties.
+**Vision** *enum* (``None``, ``Military``, ``Civilian``, ``Headlamp``): Type of unique lighting vision effect to use. Defaults to "None", which has no vision effect. Use the "Military" enumerator to use its default nightvision configuration, or when intending to assign a custom nightvision color via the color component properties. Use "Civilian" to use its default nightvision configuration. Use "Headlamp" to enable a toggleable light source, and enable the default configuration of SpotLight dictionary.
+
+SpotLight Dictionary
+````````````````````
+
+**SpotLight_Enabled** *bool*: When true, this item should have a toggleable light source. Defaults to true.
+
+**SpotLight_Range** *float*: Range of the light source's beam, in meters. Defaults to 64.
+
+**SpotLight_Angle** *float*: Angle of the light source's beam in degrees. Defaults to 90.
+
+**SpotLight_Intensity** *float*: Intensity of the light source's beam. Defaults to 1.3.
+
+**SpotLight_Color** :ref:`color <doc_data_file_format>`: Color of the light source's beam. Defaults to #f5df93.

--- a/assets/item-asset/tactical-asset.rst
+++ b/assets/item-asset/tactical-asset.rst
@@ -23,21 +23,8 @@ Tactical Asset Properties
 
 **Laser_Color** :ref:`color <doc_data_file_format>`: Overrides the default red color. When using the legacy color parsing, the ``_R``, ``_G``, and ``_B`` keys are floats within the range of [0, 1].
 
-**Light** *flag*: Provides a toggleable flashlight, and allows for using the SpotLight dictionary.
+**Light** *flag*: Provides a toggleable flashlight, and allows for using :ref:`PlayerSpotLightConfig <doc_data_playerspotlightconfig>` properties.
 
 **Melee** *flag*: Provides the ability to perform a melee attack.
 
 **Rangefinder** *flag*: Provides a toggleable rangefinder.
-
-SpotLight Dictionary
-````````````````````
-
-**SpotLight_Enabled** *bool*: When true, this item should have a toggleable light source. Defaults to true.
-
-**SpotLight_Range** *float*: Range of the light source's beam, in meters. Defaults to 64.
-
-**SpotLight_Angle** *float*: Angle of the light source's beam in degrees. Defaults to 90.
-
-**SpotLight_Intensity** *float*: Intensity of the light source's beam. Defaults to 1.3.
-
-**SpotLight_Color** :ref:`color <doc_data_file_format>`: Color of the light source's beam. Defaults to #f5df93.

--- a/assets/item-asset/tactical-asset.rst
+++ b/assets/item-asset/tactical-asset.rst
@@ -23,8 +23,21 @@ Tactical Asset Properties
 
 **Laser_Color** :ref:`color <doc_data_file_format>`: Overrides the default red color. When using the legacy color parsing, the ``_R``, ``_G``, and ``_B`` keys are floats within the range of [0, 1].
 
-**Light** *flag*: Provides a toggleable flashlight.
+**Light** *flag*: Provides a toggleable flashlight, and allows for using the SpotLight dictionary.
 
 **Melee** *flag*: Provides the ability to perform a melee attack.
 
 **Rangefinder** *flag*: Provides a toggleable rangefinder.
+
+SpotLight Dictionary
+````````````````````
+
+**SpotLight_Enabled** *bool*: When true, this item should have a toggleable light source. Defaults to true.
+
+**SpotLight_Range** *float*: Range of the light source's beam, in meters. Defaults to 64.
+
+**SpotLight_Angle** *float*: Angle of the light source's beam in degrees. Defaults to 90.
+
+**SpotLight_Intensity** *float*: Intensity of the light source's beam. Defaults to 1.3.
+
+**SpotLight_Color** :ref:`color <doc_data_file_format>`: Color of the light source's beam. Defaults to #f5df93.

--- a/assets/npc-asset/conditions.rst
+++ b/assets/npc-asset/conditions.rst
@@ -224,7 +224,7 @@ Holiday
 
 **Condition\_#\_Type** *enum* (``Holiday``)
 
-**Condition\_#\_Value** *enum* (``April_Fools``, ``Christmas``, ``Halloween``, ``None``, ``PrideMonth``, ``Valentines``): Target value, as the holiday.
+**Condition\_#\_Value** *enum* (:ref:`ENPCHoliday <doc_data_enpcholiday>`): Target value, as the holiday.
 
 Is_Full_Moon
 ````````````

--- a/data/enpcholiday.rst
+++ b/data/enpcholiday.rst
@@ -1,0 +1,23 @@
+.. _doc_data_enpcholiday:
+
+ENPCHoliday
+===========
+
+The ENPCHoliday enumerated type consists of all of the game's recognized holidays or seasonal events. The duration of most seasonal events can be found in the ``Status.json`` file packaged with the game.
+
+Enumerators
+```````````
+
+**NONE**: Represents no holiday or seasonal event.
+
+**HALLOWEEN**: Corresponds to the `Halloween <https://en.wikipedia.org/wiki/Halloween>`_ holiday.
+
+**CHRISTMAS**: Corresponds to the `Christmas <https://en.wikipedia.org/wiki/Christmas>`_ holiday, and other holidays within the festive season.
+
+**APRIL_FOOLS**: Corresponds to the `April Fools' Day <https://en.wikipedia.org/wiki/April_Fools%27_Day>`_ holiday.
+
+**VALENTINES**: Corresponds to the `Valentine's Day <https://en.wikipedia.org/wiki/Valentine%27s_Day>`_ holiday.
+
+**PRIDE_MONTH**: Corresponds to `Pride Month <https://en.wikipedia.org/wiki/Pride_Month>`_, a month-long observance in June.
+
+**MAX**: Represents all holiday or seasonal events at the same time.

--- a/data/playerspotlightconfig.rst
+++ b/data/playerspotlightconfig.rst
@@ -1,0 +1,19 @@
+.. _doc_data_playerspotlightconfig:
+
+PlayerSpotLightConfig
+=====================
+
+The PlayerSpotLightConfig struct contains properties for configuring player spot lights. Certain item assets are able to utilize these properties.
+
+Properties
+``````````
+
+**SpotLight_Enabled** *bool*: When true, this item should have a toggleable light source. Defaults to true.
+
+**SpotLight_Range** *float*: Range of the light source's beam, in meters. Defaults to 64.
+
+**SpotLight_Angle** *float*: Angle of the light source's beam in degrees. Defaults to 90.
+
+**SpotLight_Intensity** *float*: Intensity of the light source's beam. Defaults to 1.3.
+
+**SpotLight_Color** :ref:`color <doc_data_file_format>`: Color of the light source's beam. Defaults to #f5df93.

--- a/index.rst
+++ b/index.rst
@@ -118,3 +118,7 @@ Anyone can contribute towards the *Unturned* modding documentation! To submit an
 	data/guid
 	data/master-bundle-ptr
 	data/rich-text
+	
+	data/playerspotlightconfig
+	data/enpcholiday
+	


### PR DESCRIPTION
Adds the ``SpotLight_`` properties now available to tacticals/glasses.

Maybe it would make more sense for Enums and Dictionaries to have their own doc (e.g., in the **data/** folder) to reduce the number of times the same info is copy-pasted? Unsure.

For now, the info is just identical across both the tactical-asset and glasses-asset docs, and whenever melee-asset is documented it'll be the same there.