### PR TITLE
Default values for *_Items_Dropped_On_Destroy

### DIFF
--- a/assets/item-asset/placeable-asset.rst
+++ b/assets/item-asset/placeable-asset.rst
@@ -10,10 +10,10 @@ This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 Placeable Asset Properties
 --------------------------
 
-**SalvageItem** :ref:`Asset Pointer <doc_data_assetptr>`: Item added when picking up below 100% health. Defaults to a random item used in the placeable's blueprints.
+**Item_Dropped_On_Destroy** :ref:`Asset Pointer <doc_data_assetptr>`: Spawn table for items dropped when destroyed.
 
 **Min_Items_Dropped_On_Destroy** *int*: Minimum number of items to drop when destroyed. Defaults to 0.
 
 **Max_Items_Dropped_On_Destroy** *int*: Maximum number of items to drop when destroyed. Defaults to 0.
 
-**Item_Dropped_On_Destroy** :ref:`Asset Pointer <doc_data_assetptr>`: Spawn table for items dropped when destroyed.
+**SalvageItem** :ref:`Asset Pointer <doc_data_assetptr>`: Item added when picking up below 100% health. Defaults to a random item used in the placeable's blueprints.

--- a/assets/item-asset/placeable-asset.rst
+++ b/assets/item-asset/placeable-asset.rst
@@ -12,8 +12,8 @@ Placeable Asset Properties
 
 **SalvageItem** :ref:`Asset Pointer <doc_data_assetptr>`: Item added when picking up below 100% health. Defaults to a random item used in the placeable's blueprints.
 
-**Min_Items_Dropped_On_Destroy** *int*: Minimum number of items to drop when destroyed.
+**Min_Items_Dropped_On_Destroy** *int*: Minimum number of items to drop when destroyed. Defaults to 0.
 
-**Max_Items_Dropped_On_Destroy** *int*: Maximum number of items to drop when destroyed.
+**Max_Items_Dropped_On_Destroy** *int*: Maximum number of items to drop when destroyed. Defaults to 0.
 
 **Item_Dropped_On_Destroy** :ref:`Asset Pointer <doc_data_assetptr>`: Spawn table for items dropped when destroyed.


### PR DESCRIPTION
Add default values to help alleviate some potential confusion about items not dropping when these values are unset but an item spawn table is specified: https://github.com/SmartlyDressedGames/Unturned-3.x-Community/issues/3956