### PR TITLE
Fixed missing requirement for quests

### DIFF
--- a/assets/npc-asset/conditions.rst
+++ b/assets/npc-asset/conditions.rst
@@ -200,6 +200,8 @@ Quest
 
 **Condition\_#\_Status** *enum* (``None``, ``Active``, ``Ready``, ``Completed``): Current state of the quest.
 
+**Condition\_#\_Logic** *enum* (``Equal``, ``Not_Equal``): Compare current state to target state.
+
 **Condition\_#\_Ignore\_NPC** *flag*: Player does not need to be talking to an NPC within 20 meters for the quest to be completable and turned in.
 
 Reputation


### PR DESCRIPTION
The quest condition in "conditions.rst" was missing a required argument of Logic. Maybe I am wrong but I absolutely cannot get my NPC to function without that argument, I tested both it being: Quest Active; Logic Not_Equal, and Quest None; Logic Equal. Both of which functioned as intended.