### PR TITLE
Vehicle Asset documentation (revised/finished)

### DIFF
--- a/assets/vehicle-asset.rst
+++ b/assets/vehicle-asset.rst
@@ -38,7 +38,6 @@ Vehicle Properties
 ID the Spawntable to spawn when the vehicle is destroyed. Defaults to ``962``.
 
 **Drops_Min** *uint8*: Minimum amount of item drops to spawn when the vehicle is destroyed. Defaults to 3.
- Defaults to ``3``.
 
 **Drops_Max** *uint8*: Maximum amount of item drops to spawn when the vehicle is destroyed. Defaults to 7.
 

--- a/assets/vehicle-asset.rst
+++ b/assets/vehicle-asset.rst
@@ -1,0 +1,253 @@
+.. _doc_assets_vehicle:
+
+Vehicle Assets
+==============
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+
+**Type** *enum* (``Vehicle``)
+
+**Rarity** *enum* (``Common``, ``Uncommon``, ``Rare``, ``Epic``, ``Legendary``, ``Mythical``): Rarity of the vehicle, as text shown in menus and colors used for highlights. Defaults to ``Common`` rarity.
+
+**Engine** *enum* (``Blimp``, ``Boat``, ``Car``, ``Helicopter``, ``Plane``, ``Train``): Defaults to ``Car``. Some properties will only be usable depending on the ``Engine`` enumerator used, or may behave differently.
+
+**ID** *uint16*: Must be a unique identifier.
+
+Vehicle Properties
+------------------
+
+**Bicycle** *flag*: Player character should use a bicycling animation.
+
+**Bicycle_Anim_Speed** *float*: Multiplier on the speed of the bicycling animation.
+
+**Bypass_Hash_Verification** *flag*: Disable hash verification check, and allow for mismatched files.
+
+**Bypass_ID_Limit** *flag*: Allows for using an ``ID`` value within the range reserved for official content.
+
+**Cam_Driver_Offset** *float*: The vertical offset for the driver's first-person camera, in meters.
+
+**Cam_Follow_Distance** *float*: The distance behind the player the third-person camera should be placed at, in meters. Defaults to 5.5.
+
+**Cam_Passenger_Offset** *float*: The vertical offset for a passenger's first-person camera, in meters.
+
+**Can_Be_Locked** *bool*: Whether or not the vehicle can be locked a player. Defaults to true.
+
+**Crawler** *flag*: Disables the ``Wheel_#`` GameObjects from turning when steering by setting the default value of ``Num_Steering_Tires`` to 0. This property has no effect if ``Num_Steering_Tires`` has been manually set.
+
+**Drops_Table_ID** *uint16*: ID of the item spawn table to use when the vehicle is destroyed. Defaults to 962.
+ID the Spawntable to spawn when the vehicle is destroyed. Defaults to ``962``.
+
+**Drops_Min** *uint8*: Minimum amount of item drops to spawn when the vehicle is destroyed. Defaults to 3.
+ Defaults to ``3``.
+
+**Drops_Max** *uint8*: Maximum amount of item drops to spawn when the vehicle is destroyed. Defaults to 7.
+
+**Exit** *float*: Distance away from the vehicle to teleport when exiting. Defaults to 2.
+
+**Has_Clip_Prefab** *bool*: Whether or not the vehicle has a Clip.prefab. If the vehicle should use the same prefab on the server as on the client, set to false. For example, most official content uses ``Has_Clip_Prefab false``. Defaults to true.
+
+**Has_Horn** *bool*: Whether or not the vehicle should have a horn. Defaults to true when the vehicle either has a ``Horn`` AudioClip, or the ``HornAudioClip`` property has been set to a valid path. Otherwise, defaults to false.
+
+**HornAudioClip** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: AudioClip to play when using the horn.
+
+**IgnitionAudioClip** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: AudioClip to play when after entering the driver's seat.
+
+**LockMouse** *flag*: First-person camera movement is locked while driving. This is useful for ``Engine Plane`` and ``Engine Helicopter``, as a player's mouse movement while in first-person can be used to steer the vehicle.
+
+**Num_Steering_Tires** *int32*: Total number of tires that should turn when steering. Defaults to 2 when using ``Engine Car``, to 1 when using any other ``Engine`` enumerator, or to 0 if the ``Crawler`` property has been set.
+
+**Pitch_Drive** *float*: Multiplier on the pitch of the engine audio while driving. Defaults to 0.03 when using ``Engine Helicopter``, or to 0.1 when using ``Engine Blimp``. For other ``Engine`` enumerators, it defaults to 0.025 if the audio clip is named "Engine_Large", or to 0.075 if the audio clip is named "Engine_Small".
+
+**Pitch_Idle** *float*: Multiplier on the pitch of the engine audio while idle. Defaults to 0.625 if the audio clip is named "Engine_Large, or to 0.75 if the audio clip is named "Engine_Small".
+
+**Reclined** *flag*: Player character should use a reclined idle animation.
+
+**Should_Spawn_Seat_Capsules** *bool*: If true, capsule colliders will be attached to the ``Seat`` GameObject in order to prevent players from clipping into the ground. This is useful for vehicles that do not have a roof. Defaults to false.
+
+**Steering_Tire_#** *int32*: Set a ``Wheel_#`` GameObject as a steering tire, which will visibly turn when steering. By default, a number of steering tires equal to the value of ``Num_Steering_Tires`` will be automatically set. These will start at ``Steering_Tire_0 0`` (corresponding to ``Wheel_0``), and increment upwards.
+
+**Supports_Mobile_Buildables** *flag*: Barricades and other buildables cannot be placed on this vehicle.
+
+**Tire_ID** *uint16*: ID of the item that should given when a tire is manually removed with a :ref:`ToolAsset <doc_item_asset_tire>` that has ``Mode Remove``, and can also be manually attached to the vehicle if the specified item ID is for a :ref:`ToolAsset <doc_item_asset_tire>` with ``Mode Add``. Defaults to 1451.
+
+**Trunk_Storage_X** *byte*: Number of columns (horizontal storage space). Defaults to 0.
+
+**Trunk_Storage_Y** *byte*: Number of rows (vertical storage space). Defaults to 0.
+
+**Valid_Speed_Down** *float*: Configuring this will override the sanity check for reversing speed, in m/s (meters per second). Defaults to 25 when using ``Engine Car``, to 25 when using ``Engine Boat``, or to 100 otherwise.
+
+**Valid_Speed_Horizontal** *float*: Configuring this will override the sanity check for horizontal speed. This value is multiplied by PlayerInput.RATE (0.08), and then squared. Defaults to ``(Speed_Max * 0.125)^2`` when using ``Engine Helicopter`` or ``Engine Blimp``, or to ``(Speed_Max * 0.1)^2`` otherwise. This property is useful for vehicles with speed that the server cannot predict, such as force-applying Unity components.
+
+**Valid_Speed_Up** *float*: Configuring this will override the sanity check for forward speed, in m/s (meters per second). Defaults to 12.5 when using ``Engine Car``, to 3.25 when using ``Engine Boat``, or to 100 otherwise.
+
+**Zip** *flag*: Player character should use a handlebar idle animation.
+
+Handling
+````````
+
+**Air_Steer_Min** *float*: The angle to turn when moving slowly, when using ``Engine Plane``. Defaults to the value of ``Steer_Min``.
+
+**Air_Steer_Max** *float*: The angle to turn when moving quickly, when using ``Engine Plane``. Defaults to the value of ``Steer_Max``.
+
+**Air_Turn_Responsiveness** *float*: Sensitivity on steering while airborne, when using ``Engine Plane``. Defaults to 2.
+
+**Brake** *float*: The amount of braking force to apply.
+
+**Center_Of_Mass_X** *float*: Overrides the vehicle's center of mass on the 𝘟-axis, when using ``Override_Center_Of_Mass true``.
+
+**Center_Of_Mass_Y** *float*: Overrides the vehicle's center of mass on the 𝘠-axis, when using ``Override_Center_Of_Mass true``.
+
+**Center_Of_Mass_Z** *float*: Overrides the vehicle's center of mass on the 𝘡-axis, when using ``Override_Center_Of_Mass true``.
+
+**Lift** *float*: The amount of upwards lift force to apply, when using ``Engine Plane``.
+
+**Override_Center_Of_Mass** *bool*: If true, override the vehicle's center of mass with the values from the ``Center_Of_Mass_#`` Vector3 properties. This allows for modifying a vehicle's center of gravity without needing to move the ``Cog`` GameObject in Unity.
+
+**Physics_Profile** :ref:`GUID <doc_data_guid>`: GUID of a :ref:`VehiclePhysicsProfileAsset <doc_assets_vehicle_physics_profile>` to use. Using a vehicle physics profile is optional. Defaults to ``47258d0dcad14cb8be26e24c1ef3449e`` when using ``Engine Boat``, to ``6b91a94f01b6472eaca31d9420ec2367`` when using ``Engine Car``, to ``bb9f9f0204c4462ca7d976b87d1336d4`` when using ``Engine Helicopter``, or to ``93a47d6d40454335b4784e803628ac54`` when using ``Engine Plane``.
+
+**Sleds** *flag*: Tires should easily roll. For example, most planes will use this property.
+
+**Speed_Min** *float*: The vehicle's maximum reversing speed, in m/s (meters per second). In-game, a vehicle's speed is displayed as either kph (kilometers per hour) or mph (miles per hour). For example, a vehicle that uses ``Speed_Min -7`` will have a maximum reversing speed of 25.2 kph (15.66 mph).
+
+**Speed_Max** *float*: The vehicle's maximum forward speed, in m/s (meters per second). For all ``Engine`` enumerators except for the ``Train`` enumerator, this value is multiplied by 1.25 because the vehicle adjusts wheel torque trying to match a specific speed. For example, a vehicle that uses ``Speed_Max 12.5`` and is using ``Engine Car`` will have a maximum forward speed of 56.25 kph (34.95 mph).
+
+**Steer_Min** *float*: The angle to turn when moving slowly.
+
+**Steer_Max** *float*: The angle to turn when moving quickly. This value is multiplied by 0.75.
+
+**Traction** *flag*: Tires should have traction in snowy positions.
+
+**Wheel_Collider_Mass_Override** *float*: Override the mass of the vehicle's Wheel Collider components. This allows for quickly modifying the mass of the wheel colliders without needing to rebundle the asset in Unity. If a vehicle has realistic mass, then it may be helpful to set this value to something exceptionally high (e.g., 500). Defaults to ``null``.
+
+Health
+``````
+
+**Bumper_Invulnerable** *flag*: The vehicle cannot be damaged by collisions (such as with other vehicles, objects, placeables, or entities).
+
+**Bumper_Multiplier** *float*: Multiplier on the value for detecting collisions. When less than 1, the vehicle must be moving at a higher speed to enter a collision. When greater than 1, the vehicle can enter a collision while moving at a lower speed. Defaults to 1.
+
+**Can_Repair_While_Seated** *bool*: If true, a player can repair the vehicle while also sitting in it. Defaults to false.
+
+**Child_Explosion_Armor_Multiplier** *float*: Multiplier on the damage taken by barricades and other buildables placed on the vehicle, by explosions. Defaults to 0.2.
+
+**Environment_Invulnerable** *flag*: The vehicle cannot be damaged by animals, zombies, or boulders thrown by mega zombies.
+
+**Explosions_Invulnerable** *flag*: The vehicle cannot be damaged by explosions.
+
+**Health** *uint16*: Total health value. Defaults to 0.
+
+**Health_Min** *uint16*: Maximum possible health to spawn with. Defaults to 0.
+
+**Health_Max** *uint16*: Minimum possible health to spawn with. Defaults to 0.
+  
+**Invulnerable** *flag*: The vehicle cannot be damaged by lower-power :ref:`doc_item_asset_weapon` that do not have the ``Invulnerable`` flag.
+
+**Passenger_Explosion_Armor** *float*: Multiplier on the damage taken by players sitting in the vehicle, by explosions. Defaults to 1.
+
+**Tires_Invulnerable** *flag*: Tires cannot be damaged.
+
+Fuel
+````
+
+**Fuel** *uint16*: Total fuel capacity. Defaults to 0.
+
+**Fuel_Burn_Rate** *float*: The rate fuel burns at. Defaults to 2.05 when using ``Engine Car``, or to 4.2 otherwise.
+
+**Fuel_Min** *uint16*: Minimum possible fuel to spawn with. Defaults to 0.
+
+**Fuel_Max** *uint16*: Minimum possible fuel to spawn with. Defaults to 0.
+
+Battery
+```````
+
+**Battery_Burn_Rate** *float*: The rate battery charge is consumed at. Defaults to 20.
+
+**Battery_Charge_Rate** *float*: The rate battery charge is recharged at. Defaults to 20.
+
+**Battery_Powered** *flag*: The vehicle does not use fuel. For example, this flag is useful for creating electric vehicles.
+
+**Battery_Spawn_Charge_Multiplier** *float*: Multiplier on the battery charge a newly-spawned vehicle with a vehicle battery will have. Setting this to a number less than 1 will result in the vehicle spawning with less battery charge than normal. Defaults to 1.
+
+**BatteryMode_Driving** *enum* (:ref:`doc_data_ebatterymode`): How the vehicle battery should behave when a player is driving it. Defaults to ``Charge``.
+
+**BatteryMode_Empty** *enum* (:ref:`doc_data_ebatterymode`): How the vehicle battery should behave when the vehicle is empty. Defaults to ``None``.
+
+**BatteryMode_Headlights** *enum* (:ref:`doc_data_ebatterymode`): How the vehicle battery should behave when the headlights are on. Defaults to ``Burn``.
+
+**BatteryMode_Sirens** *enum* (:ref:`doc_data_ebatterymode`): How the vehicle battery should behave when the siren is on. Defaults to ``Burn``.
+
+**Can_Steal_Battery** *bool*: Whether or not the vehicle battery can be removed from the vehicle by a player. Defaults to true.
+
+**Cannot_Spawn_With_Battery** *flag*: The vehicle does not spawn with a vehicle battery.
+
+Stamina
+```````
+
+**Stamina_Boost** *float*: When a value is specified, this property allows for using stamina to boost. The value specified is the multiplier on the speed a vehicle can go without using a stamina boost. For example, ``Stamina_Boost 0.5`` would only let vehicle move at 50% its maximum speed normally, but using stamina to boost would it reach its maximum speed. This property is often used with ``Stamina_Powered``, but this is not required.
+
+**Stamina_Powered** *flag*: The vehicle does not use fuel or a vehicle battery.
+
+Explosion
+`````````
+
+**Explosion** :ref:`GUID <doc_data_guid>` or *uint16*: GUID or legacy ID of :ref:`EffectAsset <doc_assets_effect>` to play when destroyed.
+
+**Explosion_Min_Force_X** *float*: Minimum amount of force applied on the 𝘟-axis when the vehicle explodes. Defaults to 0.
+
+**Explosion_Max_Force_X** *float*: Maximum amount of force applied on the 𝘟-axis when the vehicle explodes. Defaults to 0.
+
+**Explosion_Min_Force_Y** *float*: Minimum amount of force applied on the 𝘠-axis when the vehicle explodes. This property must be set in order to use other ``Explosion_Min_Force_#`` properties. Defaults to 1024.
+
+**Explosion_Max_Force_Y** *float*: Maximum amount of force applied on the 𝘠-axis when the vehicle explodes. This property must be set in order to use other ``Explosion_Max_Force_#`` properties. Defaults to 1024.
+
+**Explosion_Min_Force_Z** *float*: Minimum amount of force applied on the 𝘡-axis when the vehicle explodes. Defaults to 0.
+
+**Explosion_Max_Force_Z** *float*: Maximum amount of force applied on the 𝘡-axis when the vehicle explodes. Defaults to 0.
+
+**ShouldExplosionCauseDamage** *bool*: If true, the explosion caused by the vehicle being destroyed will deal damage. Defaults to true if ``Explosion`` is specified.
+
+**ShouldExplosionBurnMaterials** *bool*: If true, the materials of the vehicle's ``Model_#`` GameObjects will be tinted black when the vehicle is destroyed. Defaults to true if ``Explosion`` is specified.
+
+Turret
+------
+
+**Turrets** *uint8*: Number of turrets on the vehicle. All of the other turret properties require that this property is set. Defaults to 0.
+
+**Turret_#_Seat_Index** *uint8*: Which ``Seat_#`` GameObject the turret is usable from. Defaults to 0 (corresponding to ``Seat_0``).
+
+**Turret_#_Item_ID** *uint16*: ID of the item usable from the turret seat. This is often used with a :ref:`GunAsset <doc_item_asset_gun>` that has the ``Turret`` property, but any item can be used.
+
+**Turret_#_Yaw_Min** *float*: Minimum allowed rotation of the turret through the azimuth, in degrees. If this is set to -360, it can rotate leftward forever.
+
+**Turret_#_Yaw_Max** *float*: Maximum allowed rotation of the turret through the azimuth, in degrees. If this is set to 360, it can rotate rightward forever.
+
+**Turret_#_Pitch_Min** *float*: Minimum allowed rotation of the turret through the elevation, in degrees.
+
+**Turret_#_Pitch_Max** *float*: Maximum allowed rotation of the turret through the elevation, in degrees.
+
+**Turret_#_Ignore_Aim_Camera** *flag*: Disable having the camera positioned at the ``Aim`` GameObject.
+
+Train
+`````
+
+These properties should be used with ``Engine Train``.
+
+**Train_Car_Length** *float*: The distance between each train car on the train, in meters.
+
+**Train_Track_Offset** *float*: The offset the train car is above the track, in meters.
+
+**Train_Wheel_Offset** *float*: The offset between the wheels, in meters.
+
+Economy
+```````
+
+**Shared_Skin_Lookup_ID** *uint16*: Share skins with another vehicle. Defaults to the value of ``ID``.
+
+**Shared_Skin_Name** *string*: When generating images, the image name will contain the value of this string instead of the vehicle's file name. Often used with ``Shared_Skin_Lookup_ID``.
+
+**Size2_Z** *float*: Orthogonal camera size for economy icons.
+
+Localization
+------------
+
+**Name** *string*: Vehicle name in user interfaces.

--- a/data/ebatterymode.rst
+++ b/data/ebatterymode.rst
@@ -1,0 +1,15 @@
+.. _doc_data_ebatterymode:
+
+EBatteryMode
+============
+
+The EBatteryMode enumerated type is used to determine how a vehicle battery should behave.
+
+Enumerators
+```````````
+
+**NONE**: Battery charge remains unchanged.
+
+**BURN**: Battery charge will deplete over time.
+
+**CHARGE**: Battery charge will replenish over time.

--- a/index.rst
+++ b/index.rst
@@ -76,6 +76,7 @@ Anyone can contribute towards the *Unturned* modding documentation! To submit an
 	assets/stereo-song-asset
 	assets/unity-2018
 	assets/unity-2019
+	assets/vehicle-asset
 	assets/vehicle-physics-profile-asset
 	assets/weather-asset
 	assets/zombie-difficulty-asset
@@ -96,7 +97,7 @@ Anyone can contribute towards the *Unturned* modding documentation! To submit an
 	:hidden:
 	:maxdepth: 1
 	:caption: Servers & Programming
-
+	
 	servers/command-io
 	servers/debugging-exceptions
 	servers/dedicated-workshop-update-monitor
@@ -121,5 +122,5 @@ Anyone can contribute towards the *Unturned* modding documentation! To submit an
 	data/rich-text
 	
 	data/playerspotlightconfig
+	data/ebatterymode
 	data/enpcholiday
-	

--- a/servers/game-server-login-tokens.rst
+++ b/servers/game-server-login-tokens.rst
@@ -5,7 +5,7 @@ Game Server Login Tokens
 
 Beginning in version 3.20.4.0 Unturned dedicated servers can be authenticated using a **Game Server Login Token** or **GSLT**. After version 3.21.31.0 anonymous servers (without GSLT) are hidden from the internet server list.
 
-An additional benefit of using GSLTs is the automatic transfer of favorites and history if the server address changes. This should happen within approximately 24 hours. (Verified `here <https://github.com/SmartlyDressedGames/Unturned-3.x-Community/issues/3980>`_ and `here <https://forums.alliedmods.net/showthread.php?p=2529549#post2529549>`_, thanks to CyberAndrii and joeymisfit)
+An additional benefit of using GSLTs is the automatic transfer of favorites and history if the server address changes. This should happen within approximately 24 hours. (Verified in `issue #3980 <https://github.com/SmartlyDressedGames/Unturned-3.x-Community/issues/3980>`_ and on `AlliedModders <https://forums.alliedmods.net/showthread.php?p=2529549#post2529549>`_, thanks to CyberAndrii and joeymisfit.)
 
 Creating GSLTs
 --------------


### PR DESCRIPTION
**Vehicle asset documentation.** This PR is built on top of the [PR submitted by Kopfstroh](https://github.com/SmartlyDressedGames/Unturned-Docs/pull/282). Here's a brief summary of the revisions made:

- Add a doc for EBatteryMode (an Enum used a few times by vehicle properties).
- Add an anchor to the top of the doc, and crosslink to other docs throughout.
- Removed nonexistent properties (e.g., ``SqrDelta``, ``Turret_#_Aim_Offset``).
- Added missing properties (e.g., ``Passenger_Explosion_Armor``, ``HornAudioClip``, ``Tire_ID``, ``Cam_Passenger_Offset``).
- Revised a lot of incomplete or misleading tips/details. E.g., what some properties do (like ``Train_Car_Length``), calculations a value goes through (e.g., for ``Speed_Max``), and missing default values (e.g., for ``Physics_Profile``).
- Revised section headings, and added a Localization subsection.

Also includes a commit to fix an issue that's been preventing the Docs from building. (_Duplicate explicit target name_ in GSLT doc -- two links had target name "here", which resulted in a Build-failing warning.)