### PR TITLE
ObjectAsset, ResourceAsset, and MaterialPaletteAsset

### DIFF
--- a/assets/item-asset/weapon-asset.rst
+++ b/assets/item-asset/weapon-asset.rst
@@ -78,11 +78,11 @@ Animal Damage
 Construct Damage
 ````````````````
 
-**BladeID** *byte*: Weapon can damage any resources that have a matching BladeID. Deprecated in favor of BladeIDs and BladeID\_#.
+**BladeID** *byte*: Weapon can damage any resources or objects that have a matching BladeID. Deprecated in favor of BladeIDs and BladeID\_#.
 
 **BladeIDs** *int*: Total number of unique BladeID\_# values.
 
-**BladeID_#** *byte*: Weapon can damage any resources that have a matching BladeID\_# value.
+**BladeID_#** *byte*: Weapon can damage any resources or objects that have a matching BladeID\_# value.
 
 **Barricade_Damage** *float*: Amount of damage that should be dealt to barricades, prior to modifiers.
 

--- a/assets/item-asset/weapon-asset.rst
+++ b/assets/item-asset/weapon-asset.rst
@@ -94,4 +94,4 @@ Construct Damage
 
 **Object_Damage** *float*: Amount of damage that should be dealt to objects, prior to modifiers. Defaults to the value used by Resource_Damage.
 
-**Invulnerable** *flag*: Specified if damage should affect structures, barricades, and vehicles that are considered invulnerable to low-power weaponry. Not applicable to explosive weapons, which will always ignore invulnerability.
+**Invulnerable** *flag*: Specified if damage should affect objects, structures, barricades, and vehicles that are considered invulnerable to low-power weaponry. Not applicable to explosive weapons, which will always ignore invulnerability.

--- a/assets/material-palette-asset.rst
+++ b/assets/material-palette-asset.rst
@@ -1,0 +1,35 @@
+.. _doc_assets_material_palette:
+
+Material Palette Assets
+=======================
+
+The ``MaterialPaletteAsset`` type allows an object to have multiple potential materials that it can use. A random material from the material palette is chosen every time the object is spawned in the level editor. In the level editor, material palettes can also be manually assigned to a selected object.
+
+Metadata
+--------
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+
+**Type** *string*: ``SDG.Unturned.MaterialPaletteAsset``
+
+Material Palette Properties
+---------------------------
+
+**Materials** *array* of :ref:`Master Bundle Pointer <doc_data_masterbundleptr>` *dictionaries*: Each dictionary in the list should point to a material bundled in Unity.
+
+.. code-block:: cs
+	
+	"Asset"
+	{
+		"Materials"
+		[
+			{
+				"Name" "core.masterbundle"
+				"Path" "Objects/Material_Palettes/House/House_00.mat"
+			}
+			{
+				"Name" "core.masterbundle"
+				"Path" "Objects/Material_Palettes/House/House_01.mat"
+			}
+		]
+	}

--- a/assets/object-asset.rst
+++ b/assets/object-asset.rst
@@ -93,9 +93,14 @@ Interactables
 - ``Dropper`` objects can spawn items when interacted with.
 - ``Note`` objects can display lines of text when interacted with.
 - ``Water`` objects can be siphoned for water, and ``Fuel`` objects can be siphoned for fuel.
-- ``Rubble`` objects are destructible.
+- ``Rubble`` objects are destructible. It is preferable to use ``Rubble Destroy`` instead of ``Interactability Rubble``.
 - ``NPC`` objects can provide access to dialogue, quests, and vendors.
 - ``Quest`` objects can be interacted with, but unlike other options they have no additional functionality.
+
+.. note::
+
+	Although ``Interactability`` properties can be used to create a destructible object, it is preferable to use ``Rubble`` properties as they are more specific. This allows for creating destructible objects that are also interactable.
+
 
 **Interactability_Blade_ID** *byte*: When using ``Interactability Rubble``, weapons are unable to damage this object unless they have a matching ``BladeID_#`` value. Defaults to 0.
 
@@ -108,8 +113,6 @@ Interactables
 **Interactability_Editor** *enum* (``None``, ``Toggle``): Determines how this interactable object should appear in the level editor. If this is set to ``Toggle``, then the object's alternative state will be shown. Defaults to ``None``.
 
 **Interactability_Effect** :ref:`doc_data_guid` or *uint16*: GUID or legacy ID of an :ref:`EffectAsset <doc_assets_effect>` to play when interacted with. When using ``Interactability Rubble``, this is effect is played when a section of the object is destroyed.
-
-**Interactability_Emission** *flag*: This object emits light when interacted with.
 
 **Interactability_Finale** :ref:`doc_data_guid` or *uint16*: GUID or legacy ID of an :ref:`EffectAsset <doc_assets_effect>` to play when all sections of the object using ``Interactability Rubble`` are destroyed. If this property is used, then all of the dead object's sections will also be hidden when fully destroyed.
 
@@ -146,33 +149,33 @@ Interactables
 Rubble
 ``````
 
-**Rubble** *enum* (``None``, ``Destroy``): The destruction mode that should be used, although the only functional option for this is ``Destroy``. All ``Rubble_`` properties require that this property has been set. Deprecated in favor of ``Interactability Rubble``.
+**Rubble** *enum* (``None``, ``Destroy``): The destruction mode that should be used, although the only functional option for this is ``Destroy``. All ``Rubble_`` properties require that this property has been set.
 
-**Rubble_Blade_ID** *byte*: Weapons are unable to damage this object unless they have a matching ``BladeID_#`` value. Defaults to 0. Deprecated in favor of ``Interactability_Blade_ID``.
+**Rubble_Blade_ID** *byte*: Weapons are unable to damage this object unless they have a matching ``BladeID_#`` value. Defaults to 0.
 
 **Rubble_Editor** *enum* (``Alive``, ``Dead``): Determines how this destructible object should appear in the level editor. If this is set to ``Dead``, the fully destroyed state of the object will be shown. Defaults to ``Alive``.
 
-**Rubble_Effect** :ref:`doc_data_guid` or *uint16*: GUID or legacy ID of an :ref:`EffectAsset <doc_assets_effect>` to play when a section of an object using ``Rubble`` is destroyed. Deprecated in favor of ``Interactability_Effect``.
+**Rubble_Effect** :ref:`doc_data_guid` or *uint16*: GUID or legacy ID of an :ref:`EffectAsset <doc_assets_effect>` to play when a section of the destructible object is destroyed.
 
-**Rubble_Finale** :ref:`doc_data_guid` or *uint16*: GUID or legacy ID of an :ref:`EffectAsset <doc_assets_effect>` to play when all sections of the object using ``Rubble`` are destroyed. If this property is used, then all of the dead object's sections will also be hidden when fully destroyed. Deprecated in favor of ``Interactability_Finale``.
+**Rubble_Finale** :ref:`doc_data_guid` or *uint16*: GUID or legacy ID of an :ref:`EffectAsset <doc_assets_effect>` to play when all sections of the destructible object are destroyed. If this property is used, then all of the dead object's sections will also be hidden when fully destroyed.
 
-**Rubble_Health** *uint16*: Total amount of health each section of the object has. Defaults to 0. Deprecated in favor of ``Interactability_Health``.
+**Rubble_Health** *uint16*: Total amount of health each section of the object has. Defaults to 0.
 
-**Rubble_Invulnerable** *flag*: This resource cannot be damaged by lower-power :ref:`doc_item_asset_weapon` that do not have the ``Invulnerable`` flag. Deprecated in favor of ``Interactability_Invulnerable``.
+**Rubble_Invulnerable** *flag*: This resource cannot be damaged by lower-power :ref:`doc_item_asset_weapon` that do not have the ``Invulnerable`` flag.
 
-**Rubble_Proof_Explosion** *flag*: Immune to area-of-effect explosive damage. Deprecated in favor of ``Interactability_Proof_Explosion``.
+**Rubble_Proof_Explosion** *flag*: Immune to area-of-effect explosive damage.
 
-**Rubble_Reset** *float*: Delay before a destroyed object respawns, in seconds. Deprecated in favor of ``Interactability_Reset``.
+**Rubble_Reset** *float*: Delay before a destroyed object respawns, in seconds.
 
-**Rubble_Reward_ID** *uint16*: ID of an item :ref:`spawn table <doc_assets_spawn>` to use for rewards. Defaults to 0. Deprecated in favor of ``Interactability_Reward_ID``.
+**Rubble_Reward_ID** *uint16*: ID of an item :ref:`spawn table <doc_assets_spawn>` to use for rewards. Defaults to 0.
 
-**Rubble_Rewards_Min** *byte*: Minimum amount of item drops to reward. Defaults to 1. Deprecated in favor of ``Interactability_Rewards_Min``.
+**Rubble_Rewards_Min** *byte*: Minimum amount of item drops to reward. Defaults to 1.
 
-**Rubble_Rewards_Max** *byte*: Maximum amount of item drops to reward. Defaults to 1. Deprecated in favor of ``Interactability_Rewards_Max``.
+**Rubble_Rewards_Max** *byte*: Maximum amount of item drops to reward. Defaults to 1.
 
-**Rubble_Reward_Probability** *float*: Probability of receiving a reward, as a decimal-to-percent chance. Defaults to 1. Deprecated in favor of ``Interactability_Reward_Probability``.
+**Rubble_Reward_Probability** *float*: Probability of receiving a reward, as a decimal-to-percent chance. Defaults to 1.
 
-**Rubble_Reward_XP** *uint32*: Amount of experience to reward when the object using ``Rubble`` is destroyed. Deprecated in favor of ``Interactability_Reward_XP``.
+**Rubble_Reward_XP** *uint32*: Amount of experience to reward when the destructible object is destroyed.
 
 Conditions and Rewards
 ``````````````````````

--- a/assets/object-asset.rst
+++ b/assets/object-asset.rst
@@ -46,7 +46,7 @@ Object Properties
 
 **Refill** *flag*: Water can be siphoned from this object. Deprecated in favor of ``Interactability Water``.
 
-***Snowshoe** *flag*: This object should not leave a footprint when baking materials.
+**Snowshoe** *flag*: This object should not leave a footprint when baking materials.
 
 **Soft** *flag*: Vehicles should not take damage when colliding with this object.
 
@@ -72,22 +72,30 @@ Interior Culling
 
 **LOD_Bias** *float*: Multiplier on the threshold distance for interior culling. Requires that ``LOD`` has been set.
 
-**LOD_Center_X** float: Offset for the culling volume's local position, on the 𝘟-axis.
+**LOD_Center_X** float: Offset for the culling volume's local position, on the 𝘟-axis. Requires that ``LOD`` has been set.
 
-**LOD_Center_Y** float: Offset for the culling volume's local position, on the 𝘠-axis.
+**LOD_Center_Y** float: Offset for the culling volume's local position, on the 𝘠-axis. Requires that ``LOD`` has been set.
 
-**LOD_Center_Z** float: Offset for the culling volume's local position, on the 𝘡-axis.
+**LOD_Center_Z** float: Offset for the culling volume's local position, on the 𝘡-axis. Requires that ``LOD`` has been set.
 
-**LOD_Size_X** float: Offset for the culling volume's size, on the 𝘟-axis.
+**LOD_Size_X** float: Offset for the culling volume's size, on the 𝘟-axis. Requires that ``LOD`` has been set.
 
-**LOD_Size_Y** float: Offset for the culling volume's size, on the 𝘠-axis.
+**LOD_Size_Y** float: Offset for the culling volume's size, on the 𝘠-axis. Requires that ``LOD`` has been set.
 
-**LOD_Size_Z** float: Offset for the culling volume's size, on the 𝘡-axis.
+**LOD_Size_Z** float: Offset for the culling volume's size, on the 𝘡-axis. Requires that ``LOD`` has been set.
 
 Interactables
 `````````````
 
-**Interactability** *enum* (``None``, ``Binary_State``, ``Dropper``, ``Note``, ``Water``, ``Fuel``, ``Rubble``, ``NPC``, ``Quest``): All ``Interactability_`` properties will require that this property has been set. The enumerator selected for this property will affect which properties can be used, how these properties will function when used, and how this object will behave in-game. ``Binary_State`` objects will change between their two states when interacted with – such as an open or closed door. ``Dropper`` objects can spawn items when interacted with. ``Note`` objects can display lines of text when interacted with. ``Water`` objects can be siphoned for water, and ``Fuel`` objects can be siphoned for fuel. ``Rubble`` objects are destructible. ``NPC`` objects can provide access to dialogue, quests, and vendors. ``Quest`` objects can be interacted with, and have no additional functionality unlike other options. Defaults to the ``NPC`` enumerator when using ``Type NPC``, otherwise this property will default to ``None``.
+**Interactability** *enum* (``None``, ``Binary_State``, ``Dropper``, ``Note``, ``Water``, ``Fuel``, ``Rubble``, ``NPC``, ``Quest``): All ``Interactability_`` properties will require that this property has been set. The enumerator selected for this property will affect which properties can be used, how these properties will function when used, and how this object will behave in-game. Defaults to the ``NPC`` enumerator when using ``Type NPC``, otherwise this property will default to ``None``.
+
+- ``Binary_State`` objects will change between their two states when interacted with – such as an open or closed door.
+- ``Dropper`` objects can spawn items when interacted with.
+- ``Note`` objects can display lines of text when interacted with.
+- ``Water`` objects can be siphoned for water, and ``Fuel`` objects can be siphoned for fuel.
+- ``Rubble`` objects are destructible.
+- ``NPC`` objects can provide access to dialogue, quests, and vendors.
+- ``Quest`` objects can be interacted with, but unlike other options they have no additional functionality.
 
 **Interactability_Blade_ID** *byte*: When using ``Interactability Rubble``, weapons are unable to damage this object unless they have a matching ``BladeID_#`` value. Defaults to 0.
 
@@ -171,7 +179,7 @@ Conditions and Rewards
 
 :ref:`Conditions <doc_npc_asset_conditions>` can be used to control the visibility of an object. For example, if an object should only be visible after a certain quest has been completed. These properties do not have a unique prefix, and instead use the standard ``Conditions`` and ``Condition_#`` property names.
 
-Conditions and :ref:`rewards <doc_npc_asset_rewards>` can also be tied to the interactibility of an object. An object could become interactable during a quest, and then trigger rewards (such as completing the quest) once it has been interacted with. These properties are prefixed with "Interactability_". For example, ``Interactability_Conditions`` and ``Interactability_Reward_#``.
+Conditions and :ref:`rewards <doc_npc_asset_rewards>` can also be tied to the interactability of an object. An object could become interactable during a quest, and then trigger rewards (such as completing the quest) once it has been interacted with. These properties are prefixed with ``Interactability_``. For example, ``Interactability_Conditions`` and ``Interactability_Reward_#``.
 
 Localization
 ------------

--- a/assets/object-asset.rst
+++ b/assets/object-asset.rst
@@ -1,0 +1,183 @@
+.. _doc_assets_object:
+
+Object Assets
+=============
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`doc_data_guid` documentation.
+
+**Type** *enum* (``Small``, ``Medium``, ``Large``, ``NPC``, ``Decal``): The object's type is used for sorting, pathfinding, collision, and culling. Small objects are used for clutter and decoration, medium objects fill out the layout, and large objects make up the level. When using the ``NPC`` enumerator, refer to the documentation for :ref:`doc_object_asset_npc` as well.
+
+**ID** *uint16*: Must be a unique identifier.
+
+Object Properties
+-----------------
+
+**Add_Kill_Triggers** *bool*: If true, this adds a kill volume inside the object that will kill players who clip inside it. This is helpful for preventing out-of-bounds exploits, such as players trying to build bases inside boulder objects.
+
+**Add_Night_Light_Script** *flag*: Adds a script to the object that looks for a transform named "Light". During the night, the light will be turned on. During the day, the light will be turned off.
+
+**Allow_Structures** *flag*: Structures can be built on top of this object. For example, a fake grass object may want to use this property.
+
+**Causes_Fall_Damage** *bool*: Whether or not players should take fall damage when landing on this object. Defaults to true.
+
+**Chart** *enum* (:ref:`doc_data_eobjectchart`): When an object obstructs the terrain, it can appear on a map's chart view. The pixel sampled for the object's color on the chart view can be set or overridden with this property. By default, ``Type Large`` objects use the same pixel as the ``Large`` enumerator, and ``Type Medium`` objects use the same pixel as the ``Medium`` enumerator. Defaults to ``Ignore`` when using ``Type NPC`` or ``Type Decal``. Otherwise, defaults to ``None``.
+
+**Christmas_Redirect** :ref:`doc_data_guid`: GUID of the object that should appear during the Festive holiday.
+
+**Collision_Important** *flag*: Prevent collision from being disabled. When using ``Type Large``, this flag is automatically included.
+
+**Exclude_From_Level_Batching** *bool*: Exclude this object from :ref:`level batching <doc_mapping_batching>`. This property may be helpful when using elaborate setups with Unity Event components. Defaults to true when using ``Type Decal`` or ``Type NPC``.
+
+**Foliage** :ref:`GUID <doc_data_guid>`: GUID of a :ref:`foliage asset <doc_assets_foliage>`. This property is useful for objects such as fake grass, which may want foliage to bake on top of the object similar to terrain materials.
+
+**Fuel** *flag*: Fuel can be siphoned from this object. Deprecated in favor of ``Interactability Fuel``.
+
+**Halloween_Redirect** :ref:`doc_data_guid`: GUID of the object that should appear during the Halloween holiday.
+
+**Has_Clip_Prefab** *bool*: Whether or not the object has a Clip.prefab. If the object should use the same prefab on the server as on the client, set to false. For example, most official content uses ``Has_Clip_Prefab false``. Defaults to true.
+
+**Holiday_Restriction** *enum* (:ref:`doc_data_enpcholiday`): If a valid value is specified, then this object will only be visible during the corresponding holiday. The specified holiday will be appended to the object's user-friendly name. Defaults to ``None``.
+
+**Is_Gore** *bool*: Whether or not this object should be visible if the player has disabled "Show Blood Splatters".
+
+**Landmark_Quality** *enum* (``Off``, ``Low``, ``Medium``, ``High``, ``Ultra``): The value that the "Landmarks" graphical setting must be set to in order to see a low detail model of this object from far away distances. Defaults to ``Low``.
+
+**Material_Palette** :ref:`doc_data_guid`: GUID of the :ref:`Material Palette Asset <doc_assets_material_palette>` that should be used by the object.
+
+**Refill** *flag*: Water can be siphoned from this object. Deprecated in favor of ``Interactability Water``.
+
+***Snowshoe** *flag*: This object should not leave a footprint when baking materials.
+
+**Soft** *flag*: Vehicles should not take damage when colliding with this object.
+
+**Use_Water_Height_Transparent_Sort** *flag*: Useful for transparent objects, such as glass.
+
+Decals
+``````
+
+**Decal_Alpha** *flag*: This flag should be set if the decal has a transparent texture. Requires ``Type Decal``.
+
+**Decal_X** *float*: Override the scale of the decal, on the 𝘟-axis. Requires ``Type Decal``.
+
+**Decal_Y** *float*: Override the scale of the decal, on the 𝘠-axis. Requires ``Type Decal``.
+
+**Decal_LOD_Bias** *float*: Multiplier for the LOD's switching distance. Defaults to 1. Requires ``Type Decal``.
+
+Interior Culling
+````````````````
+
+**Exclude_From_Culling_Volumes** *bool*: If set to true, this object will not be managed by culling volumes. For example, the aerospace facility on the Germany map is excluded from culling volumes, so that manually-placed culling volumes can hide large objects like shipping containers without accidentally hiding the giant aerospace facility itself.
+
+**LOD** *enum* (``None``, ``Mesh``, ``Area``): How interior culling should be determined. Using the ``Mesh`` enumerator will use the mesh bounds to determine what is inside the object. For concave objects, you can use the ``Area`` enumerator instead and add multiple Occlusion Area components for the interior volumes.
+
+**LOD_Bias** *float*: Multiplier on the threshold distance for interior culling. Requires that ``LOD`` has been set.
+
+**LOD_Center_X** float: Offset for the culling volume's local position, on the 𝘟-axis.
+
+**LOD_Center_Y** float: Offset for the culling volume's local position, on the 𝘠-axis.
+
+**LOD_Center_Z** float: Offset for the culling volume's local position, on the 𝘡-axis.
+
+**LOD_Size_X** float: Offset for the culling volume's size, on the 𝘟-axis.
+
+**LOD_Size_Y** float: Offset for the culling volume's size, on the 𝘠-axis.
+
+**LOD_Size_Z** float: Offset for the culling volume's size, on the 𝘡-axis.
+
+Interactables
+`````````````
+
+**Interactability** *enum* (``None``, ``Binary_State``, ``Dropper``, ``Note``, ``Water``, ``Fuel``, ``Rubble``, ``NPC``, ``Quest``): All ``Interactability_`` properties will require that this property has been set. The enumerator selected for this property will affect which properties can be used, how these properties will function when used, and how this object will behave in-game. ``Binary_State`` objects will change between their two states when interacted with – such as an open or closed door. ``Dropper`` objects can spawn items when interacted with. ``Note`` objects can display lines of text when interacted with. ``Water`` objects can be siphoned for water, and ``Fuel`` objects can be siphoned for fuel. ``Rubble`` objects are destructible. ``NPC`` objects can provide access to dialogue, quests, and vendors. ``Quest`` objects can be interacted with, and have no additional functionality unlike other options. Defaults to the ``NPC`` enumerator when using ``Type NPC``, otherwise this property will default to ``None``.
+
+**Interactability_Blade_ID** *byte*: When using ``Interactability Rubble``, weapons are unable to damage this object unless they have a matching ``BladeID_#`` value. Defaults to 0.
+
+**Interactability_Delay** *float*: In seconds, the cooldown before the object can be interacted with again.
+
+**Interactability_Drops** *byte*: Total number of items dropped from an object using ``Interactability Dropper``. This property is used in conjunction with ``Interactability_Drop_#``. Defaults to 0. It is preferable to use the ``Interactability_Reward_ID`` property instead.
+
+**Interactability_Drop_#** *uint16*: ID of an item that should be dropped. This property is used in conjunction with ``Interactability_Drops``.
+
+**Interactability_Editor** *enum* (``None``, ``Toggle``): Determines how this interactable object should appear in the level editor. If this is set to ``Toggle``, then the object's alternative state will be shown. Defaults to ``None``.
+
+**Interactability_Effect** :ref:`doc_data_guid` or *uint16*: GUID or legacy ID of an :ref:`EffectAsset <doc_assets_effect>` to play when interacted with. When using ``Interactability Rubble``, this is effect is played when a section of the object is destroyed.
+
+**Interactability_Emission** *flag*: This object emits light when interacted with.
+
+**Interactability_Finale** :ref:`doc_data_guid` or *uint16*: GUID or legacy ID of an :ref:`EffectAsset <doc_assets_effect>` to play when all sections of the object using ``Interactability Rubble`` are destroyed. If this property is used, then all of the dead object's sections will also be hidden when fully destroyed.
+
+**Interactability_Health** *uint16*: Total amount of health each section of the object has, when using ``Interactability Rubble``. Defaults to 0.
+
+**Interactability_Hint** *enum* (``Door``, ``Switch``, ``Fire``, ``Generator``, ``Use``, ``Custom``): Localization key to use for the interact prompt. Setting this to ``Custom`` allows for displaying custom text instead, when used in conjunction with ``Interact``.
+
+**Interactability_Invulnerable** *flag*: This resource cannot be damaged by lower-power :ref:`doc_item_asset_weapon` that do not have the ``Invulnerable`` flag, when using ``Interactability Rubble``.
+
+**Interactability_Nav** *enum* (``None``, ``On``, ``Off``): How navigation should change when the object's state is changed. Defaults to ``None``.
+
+**Interactability_Power** *enum* (``None``, ``Toggle``, ``Stay``): Whether or not this object must be powered to be usable. When set to ``None``, this object cannot be powered. When set to ``Toggle``, the object must be powered to be interacted with. When set to ``Stay``, the object must be powered to remain on. For example, a door might use ``Toggle`` if it should remain open after it loses power, while a streetlight might use ``Stay`` so that the light turns off when it loses power. Defaults to ``None``.
+
+**Interactability_Proof_Explosion** *flag*: Immune to area-of-effect explosive damage, when using ``Interactability Rubble``.
+
+**Interactability_Remote** *flag*: Disables the ability for players to interact with this via a button prompt.
+
+**Interactability_Reset** *float*: Delay before an interacted object resets, or a destroyed object respawns, in seconds.
+
+**Interactability_Resource** *uint16*: When using ``Interactability Fuel`` or ``Interactability Water``, this value is how many units of fuel or water is stored in the object. Defaults to 0.
+
+**Interactability_Reward_ID** *uint16*: ID of an item :ref:`spawn table <doc_assets_spawn>` to use for rewards, when using ``Interactability Rubble``. Defaults to 0.
+
+**Interactability_Rewards_Min** *byte*: Minimum amount of item drops to reward, when using ``Interactability Rubble``. Defaults to 1.
+
+**Interactability_Rewards_Max** *byte*: Maximum amount of item drops to reward, when using ``Interactability Rubble``. Defaults to 1.
+
+**Interactability_Reward_Probability** *float*: Probability of receiving a reward, as a decimal-to-percent chance, when using ``Interactability Rubble``. Defaults to 1.
+
+**Interactability_Reward_XP** *uint32*: Amount of experience to reward when the object using ``Interactability Rubble`` is destroyed.
+
+**Interactability_Text_Lines** *uint16*: Total number of lines to display when an object using ``Interactability Note`` is interacted with. This property is used in conjunction with ``Interactability_Text_Line_#``. Defaults to 0.
+
+Rubble
+``````
+
+**Rubble** *enum* (``None``, ``Destroy``): The destruction mode that should be used, although the only functional option for this is ``Destroy``. All ``Rubble_`` properties require that this property has been set. Deprecated in favor of ``Interactability Rubble``.
+
+**Rubble_Blade_ID** *byte*: Weapons are unable to damage this object unless they have a matching ``BladeID_#`` value. Defaults to 0. Deprecated in favor of ``Interactability_Blade_ID``.
+
+**Rubble_Editor** *enum* (``Alive``, ``Dead``): Determines how this destructible object should appear in the level editor. If this is set to ``Dead``, the fully destroyed state of the object will be shown. Defaults to ``Alive``.
+
+**Rubble_Effect** :ref:`doc_data_guid` or *uint16*: GUID or legacy ID of an :ref:`EffectAsset <doc_assets_effect>` to play when a section of an object using ``Rubble`` is destroyed. Deprecated in favor of ``Interactability_Effect``.
+
+**Rubble_Finale** :ref:`doc_data_guid` or *uint16*: GUID or legacy ID of an :ref:`EffectAsset <doc_assets_effect>` to play when all sections of the object using ``Rubble`` are destroyed. If this property is used, then all of the dead object's sections will also be hidden when fully destroyed. Deprecated in favor of ``Interactability_Finale``.
+
+**Rubble_Health** *uint16*: Total amount of health each section of the object has. Defaults to 0. Deprecated in favor of ``Interactability_Health``.
+
+**Rubble_Invulnerable** *flag*: This resource cannot be damaged by lower-power :ref:`doc_item_asset_weapon` that do not have the ``Invulnerable`` flag. Deprecated in favor of ``Interactability_Invulnerable``.
+
+**Rubble_Proof_Explosion** *flag*: Immune to area-of-effect explosive damage. Deprecated in favor of ``Interactability_Proof_Explosion``.
+
+**Rubble_Reset** *float*: Delay before a destroyed object respawns, in seconds. Deprecated in favor of ``Interactability_Reset``.
+
+**Rubble_Reward_ID** *uint16*: ID of an item :ref:`spawn table <doc_assets_spawn>` to use for rewards. Defaults to 0. Deprecated in favor of ``Interactability_Reward_ID``.
+
+**Rubble_Rewards_Min** *byte*: Minimum amount of item drops to reward. Defaults to 1. Deprecated in favor of ``Interactability_Rewards_Min``.
+
+**Rubble_Rewards_Max** *byte*: Maximum amount of item drops to reward. Defaults to 1. Deprecated in favor of ``Interactability_Rewards_Max``.
+
+**Rubble_Reward_Probability** *float*: Probability of receiving a reward, as a decimal-to-percent chance. Defaults to 1. Deprecated in favor of ``Interactability_Reward_Probability``.
+
+**Rubble_Reward_XP** *uint32*: Amount of experience to reward when the object using ``Rubble`` is destroyed. Deprecated in favor of ``Interactability_Reward_XP``.
+
+Conditions and Rewards
+``````````````````````
+
+:ref:`Conditions <doc_npc_asset_conditions>` can be used to control the visibility of an object. For example, if an object should only be visible after a certain quest has been completed. These properties do not have a unique prefix, and instead use the standard ``Conditions`` and ``Condition_#`` property names.
+
+Conditions and :ref:`rewards <doc_npc_asset_rewards>` can also be tied to the interactibility of an object. An object could become interactable during a quest, and then trigger rewards (such as completing the quest) once it has been interacted with. These properties are prefixed with "Interactability_". For example, ``Interactability_Conditions`` and ``Interactability_Reward_#``.
+
+Localization
+------------
+
+**Name** *string*: Object name in user interfaces.
+
+**Interact** *string*: When an interactable object is using ``Interactability_Hint Custom``, this property is used to set the text that should be displayed as the interact prompt for the object.
+
+**Interactability_Text_Line_#** :ref:`doc_data_richtext`: A line of text that should be displayed when an object using ``Interactability Note`` is interacted with. This property is used in conjunction with ``Interactability_Text_Lines``.

--- a/assets/resource-asset.rst
+++ b/assets/resource-asset.rst
@@ -1,0 +1,72 @@
+.. _doc_assets_resource:
+
+Resource Assets
+===============
+
+**GUID** *32-digit hexadecimal*: Refer to :ref:`doc_data_guid` documentation.
+
+**Type** *enum* (``Resource``)
+
+**ID** *uint16*: Must be a unique identifier.
+
+Resource Properties
+-------------------
+
+**Auto_Skybox** *flag*: A skybox GameObject should automatically be made for this resource.
+
+**BladeID** *byte*: Weapons are unable to damage this resource unless they have a matching ``BladeID_#`` value. Defaults to 0.
+
+**Bypass_ID_Limit** *flag*: Allows for using an ``ID`` value within the range reserved for official content.
+
+**Chart** *enum* (:ref:`doc_data_eobjectchart`): When a resource obstructs the terrain, it can appear on a map's chart view. The pixel sampled for the resource's color on the chart view can be set or overridden with this property. Defaults to ``None``, and will sample (14, 0) from the Layer_Strip.
+
+**Christmas_Redirect** :ref:`doc_data_guid`: GUID of the resource that should appear during the Festive holiday.
+
+**Exclude_From_Level_Batching** *bool*: Exclude this resource from :ref:`level batching <doc_mapping_batching>`. This property may be helpful when using elaborate setups with Unity Event components. Defaults to true when the ``SpeedTree`` flag is set.
+
+**Explosion** :ref:`GUID <doc_data_guid>` or *uint16*: GUID or legacy ID of :ref:`EffectAsset <doc_assets_effect>` to play when destroyed.
+
+**Forage** *flag*: Instead of being destroyable, this resource can be foraged from by interacting with it.
+
+**Forage_Reward_Experience** *uint32*: Amount of experience to reward when the resource is foraged from. Defaults to 1.
+
+**Halloween_Redirect** :ref:`doc_data_guid`: GUID of the resource that should appear during the Halloween holiday.
+
+**Health** *uint16*: Total amount of health the resource has. Defaults to 0.
+
+**Holiday_Restriction** *enum* (:ref:`doc_data_enpcholiday`): If a valid value is specified, then this resource will only be visible during the corresponding holiday. The specified holiday will be appended to the resource's user-friendly name. Defaults to ``None``.
+
+**Log** *uint16*: ID of an item that should be dropped when the resource is destroyed. Before multipliers, this item is dropped in bunches of 3 to 7. Defaults to 0. Deprecated in favor of ``Reward_ID``.
+
+**No_Debris** *flag*: This resource does not have debris that should appear when it has been destroyed.
+
+**Reset** *float*: Delay before respawning, in seconds.
+
+**Reward_ID** *uint16*: ID of an item :ref:`spawn table <doc_assets_spawn>` to use for rewards. Defaults to 0.
+
+**Reward_Min** *byte*: Minimum amount of item drops to reward. Defaults to 6.
+
+**Reward_Max** *byte*: Maximum amount of item drops to reward. Defaults to 9.
+
+**Reward_XP** *uint32*: Amount of experience to reward when the resource is destroyed.
+
+**Scale** *float*: The resource's scale will be multiplied by a random number between 1 and this value. This value is always parsed as its absolute (positive) value.
+
+**SpeedTree** *flag*: This resource should be considered a SpeedTree when using higher graphical settings.
+
+**SpeedTree_Default_LOD_Weights** *flag*: Use the default LOD weights intended for a SpeedTree.
+
+**Stick** *uint16*: ID of an item that should be dropped when the resource is destroyed. Before multipliers, this item is dropped in bunches of 2 to 5. Defaults to 0. Deprecated in favor of ``Reward_ID``.
+
+**Vertical_Offset** *float*: A vertical offset above or below wherever this resource is placed, in meters. Defaults to -0.75.
+
+**Vulnerable_To_All_Melee_Weapons** *bool*: When true, this resource can be damaged by melee weapons that do not have a corresponding ``BladeID_#`` value. Defaults to false.
+
+**Vulnerable_To_Fists** *bool*: When true, this resource can be damaged by a player's fists. Defaults to false.
+
+Localization
+------------
+
+**Name** *string*: Resource name in user interfaces.
+
+**Interact** *string*: Override the text shown for interactable resources using the ``Forage`` flag.

--- a/assets/resource-asset.rst
+++ b/assets/resource-asset.rst
@@ -12,7 +12,7 @@ Resource Assets
 Resource Properties
 -------------------
 
-**Auto_Skybox** *flag*: A skybox GameObject should automatically be made for this resource.
+**Auto_Skybox** *flag*: Generate and assign a material and texture to the resource's Skybox prefab. The mesh should have custom normals to match the lighting. For example, vanilla pine trees have upward normals, whereas spherical trees have outward normals.
 
 **BladeID** *byte*: Weapons are unable to damage this resource unless they have a matching ``BladeID_#`` value. Defaults to 0.
 
@@ -40,8 +40,6 @@ Resource Properties
 
 **No_Debris** *flag*: This resource does not have debris that should appear when it has been destroyed.
 
-**Radius** *float*: The radius to check when baking, in meters.
-
 **Reset** *float*: Delay before respawning, in seconds.
 
 **Reward_ID** *uint16*: ID of an item :ref:`spawn table <doc_assets_spawn>` to use for rewards. Defaults to 0.
@@ -52,7 +50,7 @@ Resource Properties
 
 **Reward_XP** *uint32*: Amount of experience to reward when the resource is destroyed.
 
-**Scale** *float*: The resource's scale will be multiplied by a random number between 1 and this value. This value is always parsed as its absolute (positive) value.
+**Scale** *float*: The value of this property is always parsed as its absolute (positive) value. An object's scale is a random number between 1.1 and the result of ``1.1 + (Scale * 2)``.
 
 **SpeedTree** *flag*: This resource should be considered a SpeedTree when using higher graphical settings.
 

--- a/assets/resource-asset.rst
+++ b/assets/resource-asset.rst
@@ -40,6 +40,8 @@ Resource Properties
 
 **No_Debris** *flag*: This resource does not have debris that should appear when it has been destroyed.
 
+**Radius** *float*: The radius to check when baking, in meters.
+
 **Reset** *float*: Delay before respawning, in seconds.
 
 **Reward_ID** *uint16*: ID of an item :ref:`spawn table <doc_assets_spawn>` to use for rewards. Defaults to 0.

--- a/data/eobjectchart.rst
+++ b/data/eobjectchart.rst
@@ -1,0 +1,31 @@
+.. _doc_data_eobjectchart:
+
+EObjectChart
+============
+
+The EObjectChart enumerated type is used to determine the how an asset should appear when generating a map's chart view. Most of the enumerators corresponds to a specific pixel coordinate on either the Height_Strip or Layer_Strip of a map's :ref:`Charts.unity3d file <doc_mapping_charts>`.
+
+Enumerators
+```````````
+
+**NONE**: Use the default for this asset.
+
+**GROUND**: Use (20, 0) from the Height_Strip.
+
+**IGNORE**: Skip this asset, and use whatever is underneath.
+
+**HIGHWAY**: Use (0, 0) from the Layer_Strip.
+
+**ROAD**: Use (1, 0) from the Layer_Strip.
+
+**STREET**: Use (2, 0) from the Layer_Strip.
+
+**PATH**: Use (3, 0) from the Layer_Strip.
+
+**LARGE**: Use (15, 0) from the Layer_Strip.
+
+**MEDIUM**: Use (16, 0) from the Layer_Strip.
+
+**WATER**: Use (0, 0) from the Height_Strip.
+
+**CLIFF**: Use (4, 0) from the Layer_Strip.

--- a/index.rst
+++ b/index.rst
@@ -68,10 +68,13 @@ Anyone can contribute towards the *Unturned* modding documentation! To submit an
 	assets/item-asset/index
 	assets/layers
 	assets/level-asset
+	assets/material-palette-asset
 	assets/mod-hooks
 	assets/npc-asset/index
+	assets/object-asset
 	assets/outfit-asset
 	assets/physics-material-asset
+	assets/resource-asset
 	assets/spawn-asset
 	assets/stereo-song-asset
 	assets/unity-2018
@@ -86,6 +89,7 @@ Anyone can contribute towards the *Unturned* modding documentation! To submit an
 	:maxdepth: 1
 	:caption: Mapping
 
+	mapping/charts
 	mapping/curated-maps
 	mapping/editor-asset-redirectors
 	mapping/favorite-searches
@@ -124,3 +128,4 @@ Anyone can contribute towards the *Unturned* modding documentation! To submit an
 	data/playerspotlightconfig
 	data/ebatterymode
 	data/enpcholiday
+	data/eobjectchart

--- a/mapping/charts.rst
+++ b/mapping/charts.rst
@@ -1,0 +1,27 @@
+.. _doc_mapping_charts:
+
+Charts
+======
+
+The Charts.unity3d file determines the colors usable by a map's chart view. This file contains two 32 × 1 px textures: "Height_Strip" and "Layer_Strip".
+
+Height_Strip
+------------
+
+Height_Strip is used for topographical colors. The leftmost pixel (0, 0) is used for water. Other pixels are sampled based on the height of the terrain, going from the lowest potential point (1, 0) to the highest potential point (31, 0).
+
+.. note:: Objects can also be configured to sample from the "Water" pixel (0, 0) or the "Ground" pixel (20, 0) of the Height_Strip.
+
+Layer_Strip
+-----------
+
+Layer_Strip is used when something obstructs the terrain, such as an object or tree. The pixel sampled depends on the type of obstruction. Objects can be configured to use a different part of the Layer_Strip than their default, with some pixels only being used by such objects.
+
+- (0, 0): Concrete roads wider than 8 meters use this pixel. Usable by objects.
+- (1, 0): Concrete roads where width is less than or equal to 8 meters use this pixel. Usable by objects.
+- (2, 0): Usable by objects.
+- (3, 0): Non-concrete roads. Usable by objects.
+- (4, 0): Usable by objects.
+- (14, 0): Resources.
+- (15, 0): Large-type objects. Usable by objects.
+- (16, 0): Medium-type objects. Usable by objects.


### PR DESCRIPTION
- Added docs for ObjectAsset, ResourceAsset, and MaterialPaletteAsset.
- Added doc about Charts.unity3d file and the texture strips for it.
- Added mentions to objects in WeaponAsset doc.

## Questions/clarifications

- I've noted all of the ``Rubble`` object properties as being "deprecated in favor of ``Interactability``". Is this note accurate?
- Objects have an ``Interactability_Emission [flag]`` property, which seems to be used by vanilla light source objects (e.g., streetlights). I'm uncertain if this property is still implemented and functional, or if it's been removed/replaced. It's currently included in the docs, but if it's nonfunctional it should be removed.
- Just want to double-check that _all_ of the ``LOD`` object properties are related to interior culling.
- Resources have an ``Auto_Skybox [flag]`` property that I've described as "A skybox GameObject should automatically be made for this resource." Is this explanation accurate?
- Resources have a ``Radius [float]`` property, but I'm unsure if this is still functional after the changes to baking in the map editor. It's currently included in the docs, but if it's nonfunctional it should be removed.
- Is there a better name/title for the Charts.unity3d file documentation than the current "Charts" titling?
- Resources have a ``Scale [float]`` property that I've described as "The resource’s scale will be multiplied by a random number between 1 and this value.". Is this description is accurate?