### PR TITLE
Property tables for hook attachments

### DIFF
--- a/assets/item-asset/barrel-asset.rst
+++ b/assets/item-asset/barrel-asset.rst
@@ -7,26 +7,108 @@ Barrel attachments are inventory items that can be attached to ranged weapons.
 
 This inherits the :ref:`CaliberAsset <doc_item_asset_caliber>` class.
 
-Item Asset Properties
----------------------
+Game Data File
+--------------
 
-**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+Barrel attachments inherit properties from the CaliberAsset class, which in turn inherits properties from the ItemAsset class. Properties that are required to be included are listed in the table below.
 
-**Type** *enum* (``Barrel``)
+.. list-table::
+   :widths: 30 40 30
+   :header-rows: 1
+   
+   * - Class
+     - Property Name
+     - Required Value
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`GUID <doc_item_asset_intro:guid>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`ID <doc_item_asset_intro:id>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`Type <doc_item_asset_intro:type>`
+     - ``Barrel``
 
-**ID** *uint16*: Must be a unique identifier.
+Properties
+``````````
 
-Barrel Asset Properties
------------------------
+.. list-table::
+   :widths: 40 40 20
+   :header-rows: 1
+   
+   * - Property Name
+     - Type
+     - Default Value
+   * - :ref:`Ballistic_Drop <doc_item_asset_barrel:ballistic_drop>`
+     - :ref:`float <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Braked <doc_item_asset_barrel:braked>`
+     - :ref:`flag <doc_data_flag>`
+     - 
+   * - :ref:`Durability <doc_item_asset_barrel:durability>`
+     - :ref:`byte <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Gunshot_Rolloff_Distance_Multiplier <doc_item_asset_barrel:gunshot_rolloff_distance_multiplier>`
+     - :ref:`float <doc_data_builtin_types>`
+     - See description
+   * - :ref:`Silenced <doc_item_asset_barrel:silenced>`
+     - :ref:`flag <doc_data_flag>`
+     - 
+   * - :ref:`Volume <doc_item_asset_barrel:volume>`
+     - :ref:`float <doc_data_builtin_types>`
+     - ``1``
 
-**Ballistic_Drop** *float*: Gravity acceleration multiplier for bullets in flight. Defaults to ``1``.
+Property Descriptions
+`````````````````````
 
-**Braked** *flag*: Muzzle flash should be hidden.
+.. _doc_item_asset_barrel:ballistic_drop:
 
-**Durability** *byte*: Amount of quality lost after each firing of the ranged weapon. When this value is greater than ``0``, the item always has a visible item quality shown. Defaults to ``0``.
+Ballistic_Drop :ref:`float <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-**Gunshot_Rolloff_Distance_Multiplier** *float*: Multiplier on gunshot rolloff distance. Defaults to ``0.5`` if ``Silenced``, otherwise to ``1``.
+Gravity acceleration multiplier for bullets in flight.
 
-**Silenced** *flag*: Alerts should not be generated.
+----
 
-**Volume** *float*: Multiplier on gunfire sound volume.
+.. _doc_item_asset_barrel:braked:
+
+Braked :ref:`flag <doc_data_flag>`
+::::::::::::::::::::::::::::::::::
+
+Muzzle flash should be hidden.
+
+----
+
+.. _doc_item_asset_barrel:durability:
+
+Durability :ref:`byte <doc_data_builtin_types>` ``0``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Amount of quality lost after each firing of the ranged weapon. When this value is greater than ``0``, the item always has a visible item quality shown.
+
+----
+
+.. _doc_item_asset_barrel:gunshot_rolloff_distance_multiplier:
+
+Gunshot_Rolloff_Distance_Multiplier :ref:`float <doc_data_builtin_types>`
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on gunshot rolloff distance. Defaults to ``0.5`` if ``Silenced``, otherwise to ``1``.
+
+----
+
+.. _doc_item_asset_barrel:silenced:
+
+Silenced :ref:`flag <doc_data_flag>`
+::::::::::::::::::::::::::::::::::::
+
+Alerts should not be generated when firing.
+
+----
+
+.. _doc_item_asset_barrel:volume:
+
+Volume :ref:`float <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on gunfire sound volume. This is often used alongside with ``Silenced``, but doing so is not required.

--- a/assets/item-asset/grip-asset.rst
+++ b/assets/item-asset/grip-asset.rst
@@ -7,16 +7,48 @@ Grip attachments are inventory items that can be attached to ranged weapons.
 
 This inherits the :ref:`CaliberAsset <doc_item_asset_caliber>` class.
 
-Item Asset Properties
----------------------
+Game Data File
+--------------
 
-**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+Grip attachments inherit properties from the CaliberAsset class, which in turn inherits properties from the ItemAsset class. Properties that are required to be included are listed in the table below.
 
-**Type** *enum* (``Grip``)
+.. list-table::
+   :widths: 30 40 30
+   :header-rows: 1
+   
+   * - Class
+     - Property Name
+     - Required Value
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`GUID <doc_item_asset_intro:guid>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`ID <doc_item_asset_intro:id>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`Type <doc_item_asset_intro:type>`
+     - ``Grip``
 
-**ID** *uint16*: Must be a unique identifier.
+Properties
+``````````
 
-Grip Asset Properties
----------------------
+.. list-table::
+   :widths: 40 40 20
+   :header-rows: 1
+   
+   * - Property Name
+     - Type
+     - Default Value
+   * - :ref:`Bipod <doc_item_asset_grip:bipod>`
+     - :ref:`flag <doc_data_flag>`
+     - 
 
-**Bipod** *flag*: Stat-changing properties from this grip attachment should only take effect while prone.
+Property Descriptions
+`````````````````````
+
+.. _doc_item_asset_grip:bipod:
+
+Bipod :ref:`flag <doc_data_flag>`
+:::::::::::::::::::::::::::::::::
+
+Stat-changing properties should only take effect while prone.

--- a/assets/item-asset/introduction.rst
+++ b/assets/item-asset/introduction.rst
@@ -340,6 +340,10 @@ GUID :ref:`doc_data_guid`
 
 Refer to :ref:`GUID <doc_data_guid>` documentation. Item assets are required to have this property.
 
+.. tip::
+
+  If the GUID property has been omitted from the asset file, then the game will automatically attempt to assign a random (and unique) GUID during a successful load.
+
 ----
 
 .. _doc_item_asset_intro:id:

--- a/assets/item-asset/sight-asset.rst
+++ b/assets/item-asset/sight-asset.rst
@@ -7,51 +7,252 @@ Sight attachments are inventory items that can be attached to ranged weapons.
 
 This inherits the :ref:`CaliberAsset <doc_item_asset_caliber>` class.
 
-Item Asset Properties
----------------------
+Game Data File
+--------------
 
-**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+Sight attachments inherit properties from the CaliberAsset class, which in turn inherits properties from the ItemAsset class. Properties that are required to be included are listed in the table below.
 
-**Type** *enum* (``Sight``)
+.. list-table::
+   :widths: 30 40 30
+   :header-rows: 1
+   
+   * - Class
+     - Property Name
+     - Required Value
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`GUID <doc_item_asset_intro:guid>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`ID <doc_item_asset_intro:id>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`Type <doc_item_asset_intro:type>`
+     - ``Sight``
 
-**ID** *uint16*: Must be a unique identifier.
+Properties
+``````````
 
-Sight Asset Properties
-----------------------
-
-**DistanceMarkers** *list of DistanceMarker*: This property is a list of :ref:`DistanceMarker dictionaries <doc_item_asset_sight:distancemarker_dictionary>`. It can be used to add visible (and accurate) distance markers to the scope that account for the weapon's bullet drop.
-
-**Holographic** *flag*: This sight should be holographic.
-
-**Nightvision_Color** :ref:`color <doc_data_file_format>`: Overrides the default color when using ``Vision Military``. When using the legacy color parsing, the ``_R``, ``_G``, and ``_B`` keys are unsigned bytes. The default value for ``Vision Civilian`` is equivalent to #666666. The default value for ``Vision Military`` is equivalent to #507814.
-
-**Nightvision_Fog_Intensity** *float*: Intensity of fog while nightvision is active. Default value for ``Vision Civilian`` is 0.5. Default value for ``Vision Military`` is 0.25.
-
-**Offset_Scope_Overlay_By_One_Texel** *bool*: If true, 2D scope texture will be scaled up slightly to center the pixel that would otherwise be left of center. Defaults to false. For example when enabled with a 512x512 texture the pixel at 255x255 will be centered on the display.
-
-**Vision** *enum* (``None``, ``Military``, ``Civilian``): Type of unique lighting vision effect to use. Defaults to "None". Use the "Military" enumerator when intending to assign a custom nightvision color via the color component properties.
-
-**Zoom** *float*: Multiplicative amount of zoom. Should be set to a value greater than 1. Defaults to 1.
-
-**ThirdPerson_Zoom** *float*: Zoom factor in third-person perspective. Should be set to a value greater than 1. Defaults to 1.25.
-
-**Zoom_Using_Eyes** *bool*: Whether main camera field of view should zoom without scope camera / scope overlay.
+.. list-table::
+   :widths: 40 40 20
+   :header-rows: 1
+   
+   * - Property Name
+     - Type
+     - Default Value
+   * - :ref:`DistanceMarkers <doc_item_asset_sight:distancemarkers>`
+     - :ref:`list of DistanceMarker <doc_item_asset_sight:distancemarker_dictionary_descriptions>`
+     - 
+   * - :ref:`Holographic <doc_item_asset_sight:holographic>`
+     - :ref:`flag <doc_data_flag>`
+     - 
+   * - :ref:`Nightvision_Color <doc_item_asset_sight:nightvision_color>`
+     - :ref:`color <doc_data_file_format>`
+     - See description
+   * - :ref:`Nightvision_Fog_Intensity <doc_item_asset_sight:nightvision_fog_intensity>`
+     - :ref:`float <doc_data_builtin_types>`
+     - See description
+   * - :ref:`Offset_Scope_Overlay_By_One_Texel <doc_item_asset_sight:offset_scope_overlay_by_one_texel>`
+     - :ref:`bool <doc_data_builtin_types>`
+     - ``false``
+   * - :ref:`Vision <doc_item_asset_sight:vision>`
+     - :ref:`ELightingVision <doc_data_elightingvision>`
+     - ``None``
+   * - :ref:`Zoom <doc_item_asset_sight:zoom>`
+     - :ref:`float <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`ThirdPerson_Zoom <doc_item_asset_sight:thirdperson_zoom>`
+     - :ref:`float <doc_data_builtin_types>`
+     - ``1.25``
+   * - :ref:`Zoom_Using_Eyes <doc_item_asset_sight:zoom_using_eyes>`
+     - :ref:`bool <doc_data_builtin_types>`
+     - ``false``
 
 .. _doc_item_asset_sight:distancemarker_dictionary:
 
-DistanceMarker Properties
--------------------------
+DistanceMarker Dictionary
+`````````````````````````
 
-.. note:: Display-related properties like **LineOffset** and **LineWidth** are a 0-1 percentage of the scope size to keep them consistent between 2D and 3D. For example 0.25 is 25%.
+.. list-table::
+   :widths: 40 40 20
+   :header-rows: 1
+   
+   * - Property Name
+     - Type
+     - Default Value
+   * - :ref:`Distance <doc_item_asset_sight:distancemarker_distance>`
+     - :ref:`float <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`LineOffset <doc_item_asset_sight:distancemarker_lineoffset>`
+     - :ref:`float <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`LineWidth <doc_item_asset_sight:distancemarker_linewidth>`
+     - :ref:`float <doc_data_builtin_types>`
+     - ``0.05``
+   * - :ref:`Side <doc_item_asset_sight:distancemarker_side>`
+     - :ref:`ESide <doc_item_asset_sight:eside_enumeration>`
+     - ``Right``
+   * - :ref:`HasLabel <doc_item_asset_sight:distancemarker_haslabel>`
+     - :ref:`bool <doc_data_builtin_types>`
+     - ``true``
+   * - :ref:`Color <doc_item_asset_sight:distancemarker_color>`
+     - :ref:`color <doc_data_file_format>`
+     - ``black``
 
-**Distance** *float*: Meters between player and target.
+.. _doc_item_asset_sight:eside_enumeration:
 
-**LineOffset** *float*: Distance between center line and start of horizontal line marker.
+ESide Enumeration
+`````````````````
 
-**LineWidth** *float*: Length of horizontal line marker. Defaults to ``0.05``.
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+   
+   * - Named Value
+     - Description
+   * - ``Left``
+     - Marking extends to the left from the center.
+   * - ``Right``
+     - Marking extends to the right from the center.
 
-**Side** *enum* (``Left``, ``Right``): Direction the horizontal line and text expand in. Defaults to ``Right``.
+Property Descriptions
+`````````````````````
 
-**HasLabel** *bool*: If true, a label with ``Distance`` text is shown next to the horizontal line marker. Defaults to ``true``.
+.. _doc_item_asset_sight:distancemarkers:
 
-**Color** :ref:`color <doc_data_file_format>`: Horizontal line and text color. Defaults to ``black``.
+DistanceMarkers :ref:`list of DistanceMarker <doc_item_asset_sight:distancemarker_dictionary_descriptions>`
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+This property is a list of :ref:`DistanceMarker dictionaries <doc_item_asset_sight:distancemarker_dictionary>`. It can be used to add visible (and accurate) distance markers to the scope that account for the weapon's bullet drop.
+
+----
+
+.. _doc_item_asset_sight:holographic:
+
+Holographic :ref:`flag <doc_data_flag>`
+:::::::::::::::::::::::::::::::::::::::
+
+This sight should be holographic.
+
+----
+
+.. _doc_item_asset_sight:nightvision_color:
+
+Nightvision_Color :ref:`color <doc_data_color>`
+:::::::::::::::::::::::::::::::::::::::::::::::
+
+Override the default nightvision color. To configure this property, the ``Vision`` property must be set to ``Military``. This property supports using legacy color parsing. When not overridden, the default nightivision color will depend on the value of the :ref:`Vision <doc_item_asset_sight:vision>` property.
+
+----
+
+.. _doc_item_asset_sight:nightvision_fog_intensity:
+
+Nightvision_Fog_Intensity :ref:`float <doc_data_builtin_types>`
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Configure the intensity of fog while nightvision is active. When this property has not been configured, the default fog intensity will depend on the value of the :ref:`Vision <doc_item_asset_sight:vision>` property.
+
+----
+
+.. _doc_item_asset_sight:offset_scope_overlay_by_one_texel:
+
+Offset_Scope_Overlay_By_One_Texel :ref:`bool <doc_data_builtin_types>` ``false``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+If ``true``, the 2D scope texture will be scaled up slightly to center the pixel that would otherwise be left of center. For example, when enabled with a 512×512 texture the pixel at 255×255 will be centered on the display.
+
+----
+
+.. _doc_item_asset_sight:vision:
+
+Vision :ref:`ELightingVision <doc_data_elightingvision>` ``None``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Set a unique lighting vision effect to use. The value of this property may effect the default values of other properties. The ``Headlamp`` enumerator is not supported by this property.
+
+----
+
+.. _doc_item_asset_sight:zoom:
+
+Zoom :ref:`float <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplicative amount of zoom. This value must be equal to or greater than ``1``.
+
+----
+
+.. _doc_item_asset_sight:thirdperson_zoom:
+
+ThirdPerson_Zoom :ref:`float <doc_data_builtin_types>` ``1.25``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Zoom factor while in the third-person perspective. This value must be equal to or greater than ``1``.
+
+----
+
+.. _doc_item_asset_sight:zoom_using_eyes:
+
+Zoom_Using_Eyes :ref:`bool <doc_data_builtin_types>` ``false``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Whether the main camera field of view should zoom without a scope overlay.
+
+.. _doc_item_asset_sight:distancemarker_dictionary_descriptions:
+
+DistanceMarker Dictionary Descriptions
+``````````````````````````````````````
+
+.. _doc_item_asset_sight:distancemarker_distance:
+
+Distance :ref:`float <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Meters between the player and a hypothethical target.
+
+----
+
+.. _doc_item_asset_sight:distancemarker_lineoffset:
+
+LineOffset :ref:`float <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Distance between center line and start of horizontal line marker.
+
+Display-related properties like ``LineOffset`` are a percentage (represented as a decimal value from 0 to 1). For example, ``0.25`` would be 25%.
+
+----
+
+.. _doc_item_asset_sight:distancemarker_linewidth:
+
+LineWidth :ref:`float <doc_data_builtin_types>` ``0.05``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Length of horizontal line marker.
+
+Display-related properties like ``LineWidth`` are a percentage (represented as a decimal value from 0 to 1). For example, ``0.25`` would be 25%.
+
+----
+
+.. _doc_item_asset_sight:distancemarker_side:
+
+Side :ref:`ESide <doc_item_asset_sight:eside_enumeration>` ``Right``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Direction the horizontal line and text expand in.
+
+----
+
+.. _doc_item_asset_sight:distancemarker_haslabel:
+
+HasLabel :ref:`bool <doc_data_builtin_types>` ``true``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+If true, a label with ``Distance`` text is shown next to the horizontal line marker.
+
+----
+
+.. _doc_item_asset_sight:distancemarker_color:
+
+Color :ref:`color <doc_data_file_format>` ``black``
+:::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Override the color of the horizontal line and text.

--- a/assets/item-asset/tactical-asset.rst
+++ b/assets/item-asset/tactical-asset.rst
@@ -7,24 +7,96 @@ Tactical attachments are inventory items that can be attached to ranged weapons.
 
 This inherits the :ref:`CaliberAsset <doc_item_asset_caliber>` class.
 
-Item Asset Properties
----------------------
+Game Data File
+--------------
 
-**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+Tactical attachments inherit properties from the CaliberAsset class, which in turn inherits properties from the ItemAsset class. Properties that are required to be included are listed in the table below.
 
-**Type** *enum* (``Tactical``)
+.. list-table::
+   :widths: 30 40 30
+   :header-rows: 1
+   
+   * - Class
+     - Property Name
+     - Required Value
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`GUID <doc_item_asset_intro:guid>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`ID <doc_item_asset_intro:id>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`Type <doc_item_asset_intro:type>`
+     - ``Tactical``
 
-**ID** *uint16*: Must be a unique identifier.
+Properties
+``````````
 
-Tactical Asset Properties
--------------------------
+.. list-table::
+   :widths: 40 40 20
+   :header-rows: 1
+   
+   * - Property Name
+     - Type
+     - Default Value
+   * - :ref:`Laser <doc_item_asset_tactical:laser>`
+     - :ref:`flag <doc_data_flag>`
+     - 
+   * - :ref:`Laser_Color <doc_item_asset_tactical:laser_color>`
+     - :ref:`color <doc_data_color>`
+     - ``#FF0000``
+   * - :ref:`Light <doc_item_asset_tactical:light>`
+     - :ref:`flag <doc_data_builtin_types>`
+     - 
+   * - :ref:`Melee <doc_item_asset_tactical:melee>`
+     - :ref:`flag <doc_data_flag>`
+     - 
+   * - :ref:`Rangefinder <doc_item_asset_tactical:rangefinder>`
+     - :ref:`flag <doc_data_flag>`
+     - 
 
-**Laser** *flag*: Provides a toggleable laser.
+Property Descriptions
+`````````````````````
 
-**Laser_Color** :ref:`color <doc_data_file_format>`: Overrides the default red color. When using the legacy color parsing, the ``_R``, ``_G``, and ``_B`` keys are floats within the range of [0, 1].
+.. _doc_item_asset_tactical:laser:
 
-**Light** *flag*: Provides a toggleable flashlight, and allows for using :ref:`PlayerSpotLightConfig <doc_data_playerspotlightconfig>` properties.
+Laser :ref:`flag <doc_data_flag>`
+:::::::::::::::::::::::::::::::::
 
-**Melee** *flag*: Provides the ability to perform a melee attack, dealing 40 damage. This damage value is not configurable.
+Provides a toggleable laser.
 
-**Rangefinder** *flag*: Provides a toggleable rangefinder.
+----
+
+.. _doc_item_asset_tactical:laser_color:
+
+Laser_Color :ref:`color <doc_data_color>` ``#FF0000``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Override the default red color with the specified value. This property supports using legacy color parsing.
+
+----
+
+.. _doc_item_asset_tactical:light:
+
+Light :ref:`flag <doc_data_flag>`
+:::::::::::::::::::::::::::::::::
+
+Provides a toggleable flashlight, and allows for using :ref:`PlayerSpotLightConfig <doc_data_playerspotlightconfig>` properties.
+
+----
+
+.. _doc_item_asset_tactical:melee:
+
+Melee :ref:`flag <doc_data_flag>`
+:::::::::::::::::::::::::::::::::
+
+Provides the ability to perform a melee attack. This attack does 40 damage, and is not configurable.
+
+----
+
+.. _doc_item_asset_tactical:rangefinder:
+
+Rangefinder :ref:`flag <doc_data_flag>`
+:::::::::::::::::::::::::::::::::::::::
+
+Provides a toggleable rangefinder.

--- a/data/struct/playerspotlightconfig.rst
+++ b/data/struct/playerspotlightconfig.rst
@@ -72,7 +72,7 @@ Intensity of the light source's beam.
 
 .. _doc_data_playerspotlightconfig:spotlight_color:
 
-SpotLight_Color :ref:`color <doc_data_file_format>` ``#f5df93``
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+SpotLight_Color :ref:`color <doc_data_color>` ``#f5df93``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Color of the light source's beam.


### PR DESCRIPTION
Replaces the lists of properties for Tactical, Sight, Barrel, and Grip assets with the newer tabular format. Two other docs have minor changes in this PR.

- BarrelAsset, GripAsset, SightAsset, and TacticalAsset have most of their docs rewritten. These rewrites are similar to the draft PR used to discuss the tabular format. Note that, unlike the draft PR, this PR also moves important info about inherited properties (like ``Type Sight`` for sight assets) into a tabular format as well.

- Intro to Items doc includes a tip about automatic GUID generation.

- Fixed an outdated internal link on the PlayerSpotLightConfig doc.