### PR TITLE
Clarify how Hair_Override works

### DIFF
--- a/assets/item-asset/gear-asset.rst
+++ b/assets/item-asset/gear-asset.rst
@@ -14,4 +14,4 @@ Gear Asset Properties
 
 **Beard** *flag*: Specified if facial hair should be visible.
 
-**Hair_Override** *string*: Optional name of a renderer that should use the player's hair material. Used by hats which entirely cover the player's hair so that the hair color can still be used for customization.
+**Hair_Override** *string*: When this property is set, the game will look for a child Mesh Renderer component in Unity that has the same name as this property's value. If a matching Mesh Renderer is found, its material will be changed to the character's hair material. This property is used by certain cosmetics that entirely cover the character's hair, so that the player's selected hair color can still be used for customization.

--- a/servers/server-hosting.rst
+++ b/servers/server-hosting.rst
@@ -194,7 +194,7 @@ Examples:
 
 Game rules, listing display, and many other options are available in the ``Config.json`` file. Game options mirror the in-game Play > Singleplayer > Config menu. This file deserves further documentation, but is not officially documented yet.
 
-Steam Workshop add-ons (e.g., maps, items, vehicles) are setup in the ``WorkshopDownloadConfig.json`` file.
+Steam Workshop add-ons (e.g., maps, items, vehicles, collections) are setup in the ``WorkshopDownloadConfig.json`` file.
 To include a Workshop file on your server:
 
 1. Browse to its web page, for example: `Hawaii <https://steamcommunity.com/sharedfiles/filedetails/?id=1753134636>`_


### PR DESCRIPTION
- Rewrites the `Hair_Override` property description to provide more information about how modders can implement this feature. https://forum.smartlydressedgames.com/t/how-to-make-a-skin-that-uses-hair-color/24028/2
- Added "collections" (i.e., Steam Workshop collections/modpacks) to the list of things that can be added to the server's `WorkshopDownloadConfig.json`.