### PR TITLE
OpenGraph support

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -18,6 +18,7 @@ extensions = [
     'sphinx.ext.autosectionlabel', # create explicit targets for all sections in the form of {path/to/page}:{title-of-section}
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
+    'sphinxext.opengraph', # OpenGraph support (e.g., URLs posted onto our Discourse forum will appear as OneBox embeds)
     'sphinx_rtd_theme', # "Read the Docs Sphinx Theme" https://sphinx-rtd-theme.readthedocs.io/en/stable/index.html
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sphinx_rtd_theme
+sphinxext-opengraph


### PR DESCRIPTION
This extension generates OpenGraph metadata for each doc page. This allows for other sites (that support Open Graph protocol) to render embedded links using content from the original webpage/metadata.

E.g., URLs posted onto our Discourse forum should appear as OneBox embeds.