### PR TITLE
MagazineAsset property table

### DIFF
--- a/assets/item-asset/barrel-asset.rst
+++ b/assets/item-asset/barrel-asset.rst
@@ -40,22 +40,22 @@ Properties
      - Type
      - Default Value
    * - :ref:`Ballistic_Drop <doc_item_asset_barrel:ballistic_drop>`
-     - :ref:`float <doc_data_builtin_types>`
+     - :ref:`float32 <doc_data_builtin_types>`
      - ``1``
    * - :ref:`Braked <doc_item_asset_barrel:braked>`
      - :ref:`flag <doc_data_flag>`
      - 
    * - :ref:`Durability <doc_item_asset_barrel:durability>`
-     - :ref:`byte <doc_data_builtin_types>`
+     - :ref:`uint8 <doc_data_builtin_types>`
      - ``0``
    * - :ref:`Gunshot_Rolloff_Distance_Multiplier <doc_item_asset_barrel:gunshot_rolloff_distance_multiplier>`
-     - :ref:`float <doc_data_builtin_types>`
+     - :ref:`float32 <doc_data_builtin_types>`
      - See description
    * - :ref:`Silenced <doc_item_asset_barrel:silenced>`
      - :ref:`flag <doc_data_flag>`
      - 
    * - :ref:`Volume <doc_item_asset_barrel:volume>`
-     - :ref:`float <doc_data_builtin_types>`
+     - :ref:`float32 <doc_data_builtin_types>`
      - ``1``
 
 Property Descriptions
@@ -63,8 +63,8 @@ Property Descriptions
 
 .. _doc_item_asset_barrel:ballistic_drop:
 
-Ballistic_Drop :ref:`float <doc_data_builtin_types>` ``1``
-::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+Ballistic_Drop :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Gravity acceleration multiplier for bullets in flight.
 
@@ -81,8 +81,8 @@ Muzzle flash should be hidden.
 
 .. _doc_item_asset_barrel:durability:
 
-Durability :ref:`byte <doc_data_builtin_types>` ``0``
-:::::::::::::::::::::::::::::::::::::::::::::::::::::
+Durability :ref:`uint8 <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Amount of quality lost after each firing of the ranged weapon. When this value is greater than ``0``, the item always has a visible item quality shown.
 
@@ -90,8 +90,8 @@ Amount of quality lost after each firing of the ranged weapon. When this value i
 
 .. _doc_item_asset_barrel:gunshot_rolloff_distance_multiplier:
 
-Gunshot_Rolloff_Distance_Multiplier :ref:`float <doc_data_builtin_types>`
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+Gunshot_Rolloff_Distance_Multiplier :ref:`float32 <doc_data_builtin_types>`
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Multiplier on gunshot rolloff distance. Defaults to ``0.5`` if ``Silenced``, otherwise to ``1``.
 
@@ -108,7 +108,7 @@ Alerts should not be generated when firing.
 
 .. _doc_item_asset_barrel:volume:
 
-Volume :ref:`float <doc_data_builtin_types>` ``1``
-::::::::::::::::::::::::::::::::::::::::::::::::::
+Volume :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Multiplier on gunfire sound volume. This is often used alongside with ``Silenced``, but doing so is not required.

--- a/assets/item-asset/magazine-asset.rst
+++ b/assets/item-asset/magazine-asset.rst
@@ -7,60 +7,312 @@ Magazine attachments are inventory items that can be attached to ranged weapons.
 
 This inherits the :ref:`CaliberAsset <doc_item_asset_caliber>` class.
 
-Item Asset Properties
----------------------
+Game Data File
+--------------
 
-**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+Magazine attachments inherit properties from the CaliberAsset class, which in turn inherits properties from the ItemAsset class. Properties that are required to be included are listed in the table below.
 
-**Type** *enum* (``Magazine``)
+.. list-table::
+   :widths: 30 40 30
+   :header-rows: 1
+   
+   * - Class
+     - Property Name
+     - Required Value
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`GUID <doc_item_asset_intro:guid>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`ID <doc_item_asset_intro:id>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`Type <doc_item_asset_intro:type>`
+     - ``Magazine``
 
-**ID** *uint16*: Must be a unique identifier.
+Properties
+``````````
 
-Magazine Asset Properties
--------------------------
+.. list-table::
+   :widths: 40 40 20
+   :header-rows: 1
+   
+   * - Property Name
+     - Type
+     - Default Value
+   * - :ref:`Animal_Damage <doc_item_asset_magazine:animal_damage>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Barricade_Damage <doc_item_asset_magazine:barricade_damage>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Delete_Empty <doc_item_asset_magazine:delete_empty>`
+     - :ref:`flag <doc_data_flag>`
+     - 
+   * - :ref:`Explosion <doc_item_asset_magazine:explosion>`
+     - :ref:`doc_data_guid` or :ref:`uint16 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Explosion_Launch_Speed <doc_item_asset_magazine:explosion_launch_speed>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - See description
+   * - :ref:`Explosive <doc_item_asset_magazine:explosive>`
+     - :ref:`flag <doc_data_flag>`
+     - 
+   * - :ref:`Impact <doc_item_asset_magazine:impact>`
+     - :ref:`doc_data_guid` or :ref:`uint16 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Object_Damage <doc_item_asset_magazine:object_damage>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - See description
+   * - :ref:`Pellets <doc_item_asset_magazine:pellets>`
+     - :ref:`uint8 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Player_Damage <doc_item_asset_magazine:player_damage>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Projectile_Blast_Radius_Multiplier <doc_item_asset_magazine:projectile_blast_radius_multiplier>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Projectile_Damage_Multiplier <doc_item_asset_magazine:projectile_damage_multiplier>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Projectile_Launch_Force_Multiplier <doc_item_asset_magazine:projectile_launch_force_multiplier>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Range <doc_item_asset_magazine:range>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Resource_Damage <doc_item_asset_magazine:resource_damage>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Should_Fill_After_Detach <doc_item_asset_magazine:should_fill_after_detach>`
+     - :ref:`bool <doc_data_builtin_types>`
+     - ``false``
+   * - :ref:`Spawn_Explosion_On_Dedicated_Server <doc_item_asset_magazine:spawn_explosion_on_dedicated_server>`
+     - :ref:`flag <doc_data_flag>`
+     - 
+   * - :ref:`Speed <doc_item_asset_magazine:speed>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Structure_Damage <doc_item_asset_magazine:structure_damage>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Stuck <doc_item_asset_magazine:stuck>`
+     - :ref:`uint8 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Tracer <doc_item_asset_magazine:tracer>`
+     - :ref:`doc_data_guid` or :ref:`uint16 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Vehicle_Damage <doc_item_asset_magazine:vehicle_damage>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Zombie_Damage <doc_item_asset_magazine:zombie_damage>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``0``
 
-**Pellets** *byte*: Number of bullet rays shot. Defaults to 1.
+Property Descriptions
+`````````````````````
 
-**Projectile_Damage_Multiplier** *float*: Multiplier on the damage dealt by projectile weapons.
+.. _doc_item_asset_magazine:animal_damage:
 
-**Projectile_Blast_Radius_Multiplier** *float*: Multiplier on the blast radius of projectiles fired from projectile weapons.
+Animal_Damage :ref:`float32 <doc_data_builtin_types>` ``0``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-**Projectile_Launch_Force_Multiplier** *float*: Multiplier on the launch force applied to projectiles fired from projectile weapons.
+Damage dealt to animals caught within the area-of-effect explosion of a magazine attachment using the ``Explosive`` flag.
 
-**Speed** *float*: Multiplier on reload speed. Defaults to 1.
+----
 
-**Stuck** *byte*: Amount of quality to lose when hit. When this value is greater than 0, fired projectiles can be picked back up until their quality reaches 0. Defaults to 0.
+.. _doc_item_asset_magazine:barricade_damage:
 
-**Explosive** *flag*: Specified if it should cause an area-of-effect explosion.
+Barricade_Damage :ref:`float32 <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-**Range** *float*: Radius of the area-of-effect explosion.
+Damage dealt to barricades caught within the area-of-effect explosion of a magazine attachment using the ``Explosive`` flag.
 
-**Player_Damage** *float*: Damage dealt to players caught in the area-of-effect explosion.
+----
 
-**Zombie_Damage** *float*: Damage dealt to zombies caught in the area-of-effect explosion.
+.. _doc_item_asset_magazine:delete_empty:
 
-**Animal_Damage** *float*: Damage dealt to animals caught in the area-of-effect explosion.
+Delete_Empty :ref:`flag <doc_data_flag>`
+::::::::::::::::::::::::::::::::::::::::
 
-**Barricade_Damage** *float*: Damage dealt to barricades caught in the area-of-effect explosion.
+The magazine attachment should be deleted when it is fully depleted.
 
-**Structure_Damage** *float*: Damage dealt to structures caught in the area-of-effect explosion.
+----
 
-**Vehicle_Damage** *float*: Damage dealt to vehicles caught in the area-of-effect explosion.
+.. _doc_item_asset_magazine:explosion:
 
-**Resource_Damage** *float*: Damage dealt to resources caught in the area-of-effect explosion.
+Explosion :ref:`doc_data_guid` or :ref:`uint16 <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-**Object_Damage** *float*: Damage dealt to objects caught in the area-of-effect explosion. Defaults to the value used by ``Resource_Damage``.
+GUID or legacy ID of the effect that should be used for explosions caused by magazine attachment using the ``Explosive`` flag.
 
-**Explosion_Launch_Speed** *float*: Launch speed of players caught within the area-of-effect explosion, in meters per second. Defaults to the resulting value from ``Player_Damage * 0.1``. 
+----
 
-**Explosion** :ref:`doc_data_guid` or *uint16*: GUID or legacy ID of explosion effect. Defaults to 0.
+.. _doc_item_asset_magazine:explosion_launch_speed:
 
-**Spawn_Explosion_On_Dedicated_Server** *bool*: Specified to spawn the explosion effect on the server.
+Explosion_Launch_Speed :ref:`float32 <doc_data_builtin_types>`
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-**Tracer** :ref:`doc_data_guid` or *GUID*: GUID or legacy ID of bullet tracer effect. Defaults to 0.
+Players caught within the area-of-effect explosion caused by projectiles when using the ``Explosive`` property are launched at this speed, in meters per second. Defaults to the resulting value of ``Player_Damage * 0.1``.
 
-**Impact** :ref:`doc_data_guid` or *GUID*: GUID or legacy ID of effect to play on impact. Defaults to 0.
+----
 
-**Delete_Empty** *flag*: Specified if the magazine attachment should be deleted when it is fully depleted.
+.. _doc_item_asset_magazine:explosive:
 
-**Should_Fill_After_Detach** *bool*: Ammunition should be fully refilled after the magazine attachment is detached from a ranged weapon. Defaults to false.
+Explosive :ref:`flag <doc_data_flag>`
+:::::::::::::::::::::::::::::::::::::
+
+When this flag is included, the projectile fired from a ballistics projectile weapon will cause an area-of-effect explosion. This is typically used alongside the ``Range`` property.
+
+----
+
+.. _doc_item_asset_magazine:impact:
+
+Impact :ref:`doc_data_guid` or :ref:`uint16 <doc_data_builtin_types>` ``0``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+GUID or legacy ID of the effect that should be play on impact.
+
+----
+
+.. _doc_item_asset_magazine:object_damage:
+
+Object_Damage :ref:`float32 <doc_data_builtin_types>`
+:::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Damage dealt to players caught within the area-of-effect explosion of a magazine attachment using the ``Explosive`` flag. Defaults to the value of the ``Resource_Damage`` property.
+
+----
+
+.. _doc_item_asset_magazine:pellets:
+
+Pellets :ref:`uint8 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Number of bullet rays shot.
+
+----
+
+.. _doc_item_asset_magazine:player_damage:
+
+Player_Damage :ref:`float32 <doc_data_builtin_types>` ``0``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Damage dealt to players caught within the area-of-effect explosion of a magazine attachment using the ``Explosive`` flag.
+
+----
+
+.. _doc_item_asset_magazine:projectile_blast_radius_multiplier:
+
+Projectile_Blast_Radius_Multiplier :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on the blast radius of the explosive projectiles fired from physics projectile weapons.
+
+----
+
+.. _doc_item_asset_magazine:projectile_damage_multiplier:
+
+Projectile_Damage_Multiplier :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on the damage dealt by the explosive projectiles fired from physics projectile weapons.
+
+----
+
+.. _doc_item_asset_magazine:projectile_launch_force_multiplier:
+
+Projectile_Launch_Force_Multiplier :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on the launch force applied to the explosive projectiles fired from physics projectile weapons.
+
+----
+
+.. _doc_item_asset_magazine:range:
+
+Range :ref:`float32 <doc_data_builtin_types>` ``0``
+:::::::::::::::::::::::::::::::::::::::::::::::::::
+
+In meters, the radius of the area-of-effect explosion caused by a projectile when a magazine attachment is using the ``Explosive`` flag.
+
+----
+
+.. _doc_item_asset_magazine:resource_damage:
+
+Resource_Damage :ref:`float32 <doc_data_builtin_types>` ``0``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Damage dealt to resources caught within the area-of-effect explosion of a magazine attachment using the ``Explosive`` flag.
+
+----
+
+.. _doc_item_asset_magazine:should_fill_after_detach:
+
+Should_Fill_After_Detach :ref:`bool <doc_data_builtin_types>` ``false``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Ammunition should be fully refilled after the magazine attachment is detached from a ranged weapon.
+
+----
+
+.. _doc_item_asset_magazine:spawn_explosion_on_dedicated_server:
+
+Spawn_Explosion_On_Dedicated_Server :ref:`flag <doc_data_flag>`
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+When using the ``Explosion`` property, spawn the explosion effect on the server.
+
+----
+
+.. _doc_item_asset_magazine:speed:
+
+Speed :ref:`float32 <doc_data_builtin_types>` ``1``
+:::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on reload speed.
+
+----
+
+.. _doc_item_asset_magazine:structure_damage:
+
+Structure_Damage :ref:`float32 <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Damage dealt to structures caught within the area-of-effect explosion of a magazine attachment using the ``Explosive`` flag.
+
+----
+
+.. _doc_item_asset_magazine:stuck:
+
+Stuck :ref:`uint8 <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+The amount of quality that should be lost after the projectile hits something. When this value is greater than ``0``, the item will have a visible quality value. This property is typically used with :ref:`ranged weapons <doc_item_asset_gun>` utilizing the ``Action String`` key-value pair, such as a crossbow.
+
+----
+
+.. _doc_item_asset_magazine:tracer:
+
+Tracer :ref:`doc_data_guid` or :ref:`uint16 <doc_data_builtin_types>` ``0``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+GUID or legacy ID of the effect that should be used for bullet tracers.
+
+----
+
+.. _doc_item_asset_magazine:vehicle_damage:
+
+Vehicle_Damage :ref:`float32 <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Damage dealt to vehicles caught within the area-of-effect explosion of a magazine attachment using the ``Explosive`` flag.
+
+----
+
+.. _doc_item_asset_magazine:zombie_damage:
+
+Zombie_Damage :ref:`float32 <doc_data_builtin_types>` ``0``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Damage dealt to zombies caught within the area-of-effect explosion of a magazine attachment using the ``Explosive`` flag.

--- a/assets/item-asset/sight-asset.rst
+++ b/assets/item-asset/sight-asset.rst
@@ -49,7 +49,7 @@ Properties
      - :ref:`color <doc_data_file_format>`
      - See description
    * - :ref:`Nightvision_Fog_Intensity <doc_item_asset_sight:nightvision_fog_intensity>`
-     - :ref:`float <doc_data_builtin_types>`
+     - :ref:`float32 <doc_data_builtin_types>`
      - See description
    * - :ref:`Offset_Scope_Overlay_By_One_Texel <doc_item_asset_sight:offset_scope_overlay_by_one_texel>`
      - :ref:`bool <doc_data_builtin_types>`
@@ -58,10 +58,10 @@ Properties
      - :ref:`ELightingVision <doc_data_elightingvision>`
      - ``None``
    * - :ref:`Zoom <doc_item_asset_sight:zoom>`
-     - :ref:`float <doc_data_builtin_types>`
+     - :ref:`float32 <doc_data_builtin_types>`
      - ``1``
    * - :ref:`ThirdPerson_Zoom <doc_item_asset_sight:thirdperson_zoom>`
-     - :ref:`float <doc_data_builtin_types>`
+     - :ref:`float32 <doc_data_builtin_types>`
      - ``1.25``
    * - :ref:`Zoom_Using_Eyes <doc_item_asset_sight:zoom_using_eyes>`
      - :ref:`bool <doc_data_builtin_types>`
@@ -80,13 +80,13 @@ DistanceMarker Dictionary
      - Type
      - Default Value
    * - :ref:`Distance <doc_item_asset_sight:distancemarker_distance>`
-     - :ref:`float <doc_data_builtin_types>`
+     - :ref:`float32 <doc_data_builtin_types>`
      - ``0``
    * - :ref:`LineOffset <doc_item_asset_sight:distancemarker_lineoffset>`
-     - :ref:`float <doc_data_builtin_types>`
+     - :ref:`float32 <doc_data_builtin_types>`
      - ``0``
    * - :ref:`LineWidth <doc_item_asset_sight:distancemarker_linewidth>`
-     - :ref:`float <doc_data_builtin_types>`
+     - :ref:`float32 <doc_data_builtin_types>`
      - ``0.05``
    * - :ref:`Side <doc_item_asset_sight:distancemarker_side>`
      - :ref:`ESide <doc_item_asset_sight:eside_enumeration>`
@@ -146,8 +146,8 @@ Override the default nightvision color. To configure this property, the ``Vision
 
 .. _doc_item_asset_sight:nightvision_fog_intensity:
 
-Nightvision_Fog_Intensity :ref:`float <doc_data_builtin_types>`
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+Nightvision_Fog_Intensity :ref:`float32 <doc_data_builtin_types>`
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Configure the intensity of fog while nightvision is active. When this property has not been configured, the default fog intensity will depend on the value of the :ref:`Vision <doc_item_asset_sight:vision>` property.
 
@@ -173,8 +173,8 @@ Set a unique lighting vision effect to use. The value of this property may effec
 
 .. _doc_item_asset_sight:zoom:
 
-Zoom :ref:`float <doc_data_builtin_types>` ``1``
-::::::::::::::::::::::::::::::::::::::::::::::::
+Zoom :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Multiplicative amount of zoom. This value must be equal to or greater than ``1``.
 
@@ -182,8 +182,8 @@ Multiplicative amount of zoom. This value must be equal to or greater than ``1``
 
 .. _doc_item_asset_sight:thirdperson_zoom:
 
-ThirdPerson_Zoom :ref:`float <doc_data_builtin_types>` ``1.25``
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+ThirdPerson_Zoom :ref:`float32 <doc_data_builtin_types>` ``1.25``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Zoom factor while in the third-person perspective. This value must be equal to or greater than ``1``.
 
@@ -203,8 +203,8 @@ DistanceMarker Dictionary Descriptions
 
 .. _doc_item_asset_sight:distancemarker_distance:
 
-Distance :ref:`float <doc_data_builtin_types>` ``0``
-::::::::::::::::::::::::::::::::::::::::::::::::::::
+Distance :ref:`float32 <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Meters between the player and a hypothethical target.
 
@@ -212,8 +212,8 @@ Meters between the player and a hypothethical target.
 
 .. _doc_item_asset_sight:distancemarker_lineoffset:
 
-LineOffset :ref:`float <doc_data_builtin_types>` ``0``
-::::::::::::::::::::::::::::::::::::::::::::::::::::::
+LineOffset :ref:`float32 <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Distance between center line and start of horizontal line marker.
 
@@ -223,8 +223,8 @@ Display-related properties like ``LineOffset`` are a percentage (represented as 
 
 .. _doc_item_asset_sight:distancemarker_linewidth:
 
-LineWidth :ref:`float <doc_data_builtin_types>` ``0.05``
-::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+LineWidth :ref:`float32 <doc_data_builtin_types>` ``0.05``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Length of horizontal line marker.
 


### PR DESCRIPTION
Rewrites the doc for ItemMagazineAsset to use a table for properties -- following the same formatting as other recently-updated docs.

Also fixes the terms used for certain data types in a couple docs (e.g., "float32" and "uint8" instead of "float" and "byte".)