### PR TITLE
New example for Crafting Blacklist's "Input_Items"

### DIFF
--- a/assets/crafting-blacklist-asset.rst
+++ b/assets/crafting-blacklist-asset.rst
@@ -45,4 +45,4 @@ Prevents specific items or blueprints from being used while crafting. They are h
 		}
 	]
 
-**Allow_Core_Blueprints** *bool*: Defaults to true. If false, blueprints from the vanilla/built-in items are not allowed.
+**Allow_Core_Blueprints** *bool*: Defaults to ``true``. If ``false``, blueprints from the vanilla/built-in items are not allowed.

--- a/assets/crafting-blacklist-asset.rst
+++ b/assets/crafting-blacklist-asset.rst
@@ -7,19 +7,28 @@ Prevents specific items or blueprints from being used while crafting. They are h
 
 **Type** *string*: ``SDG.Unturned.CraftingBlacklistAsset``
 
-**Input_Items** array of Item :ref:`Asset Pointers <doc_data_assetptr>`: Any blueprints consuming these items cannot be crafted.
+**Input_Items** array of Item :ref:`Asset Pointers <doc_data_assetptr>`: Any blueprints consuming these items cannot be crafted. For example (blacklisted items are highlighted):
 
-.. code-block:: text
+.. code-block:: cpp
+  :linenos:
+  :emphasize-lines: 4, 7-10, 13-16
 
-	Input_Items
+	"Input_Items"
 	[
-		### this is a GUID number ###
-		### guid ###
+		// Orange Hoodie
+		"GUID" "67c76cdf16024bf68b6e5d14d4c617ab"
+		
+		// Individual items can also be enclosed in brackets { }
 		{
-			// eaglefire
+			// Eaglefire
 			GUID b03d581a5c1a490f995f8deba57b0f17
 		}
-		### another GUID number ###
+
+		// Jeans
+		dab78cc4d66645bfb8169be7c15cf876
+		55c69817a31448b685c7f788ec7d2d0c
+		bdae9d26ca704d729b2b0f34812d2a36
+		67a6ec52e4b24ffd89f75ceee0eb5179
 	]
 
 **Output_Items** array of Item :ref:`Asset Pointers <doc_data_assetptr>`: Any blueprints generating these items cannot be crafted.

--- a/assets/crafting-blacklist-asset.rst
+++ b/assets/crafting-blacklist-asset.rst
@@ -10,8 +10,8 @@ Prevents specific items or blueprints from being used while crafting. They are h
 **Input_Items** array of Item :ref:`Asset Pointers <doc_data_assetptr>`: Any blueprints consuming these items cannot be crafted. For example (blacklisted items are highlighted):
 
 .. code-block:: cpp
-  :linenos:
-  :emphasize-lines: 4, 7-10, 13-16
+	:linenos:
+	:emphasize-lines: 4, 7-10, 13-16
 
 	Input_Items
 	[

--- a/assets/crafting-blacklist-asset.rst
+++ b/assets/crafting-blacklist-asset.rst
@@ -13,7 +13,7 @@ Prevents specific items or blueprints from being used while crafting. They are h
   :linenos:
   :emphasize-lines: 4, 7-10, 13-16
 
-	"Input_Items"
+	Input_Items
 	[
 		// Orange Hoodie
 		"GUID" "67c76cdf16024bf68b6e5d14d4c617ab"
@@ -23,7 +23,7 @@ Prevents specific items or blueprints from being used while crafting. They are h
 			// Eaglefire
 			GUID b03d581a5c1a490f995f8deba57b0f17
 		}
-
+		
 		// Jeans
 		dab78cc4d66645bfb8169be7c15cf876
 		55c69817a31448b685c7f788ec7d2d0c


### PR DESCRIPTION
While reading a player's [forum post](https://forum.smartlydressedgames.com/t/level-blacklist/24147), I realized our example could be clearer. It reiterates some info from Asset Definitions or Asset Pointers, but should be helpful irregardless. Although we could instead have an example with only a single (preferred) syntax, like inline.

- Placeholder text has been replaced.
- Relevant lines are highlighted.
- Although .asset files are _not_ .cpp files, I believe including syntax highlighting when possible (& not misleading) would be helpful for readability. Maybe you have some thoughts here – or know a language that would be more "accurate" while still providing highlighting?

![](https://github.com/SmartlyDressedGames/Unturned-Docs/assets/7608445/ad4a71b6-b9a2-4973-9dc3-b10064736452)

- Current https://docs.smartlydressedgames.com/en/stable/assets/crafting-blacklist-asset.html
- Revised https://unturned--309.org.readthedocs.build/en/309/assets/crafting-blacklist-asset.html