### PR TITLE
EItemOrigin

### DIFF
--- a/assets/npc-asset/rewards.rst
+++ b/assets/npc-asset/rewards.rst
@@ -116,7 +116,7 @@ Item
 
 **Reward_#_Magazine** *uint16*: Override for the magazine attachment that should be attached to the item reward.
 
-**Reward_#_Origin** *enum* (``World``, ``Admin``, ``Craft``, ``Nature``): Set the item origin. For example, setting the origin to ``Admin`` will cause items to spawn at full quality. Defaults to `Craft`.
+**Reward_#_Origin** :ref:`doc_data_eitemorigin`: Set the item origin. For example, setting the origin to ``Admin`` will cause items to spawn at full quality. Defaults to `Craft`.
 
 **Reward_#_Sight** *uint16*: Override for the sight attachment that should be attached to the item reward.
 
@@ -133,7 +133,7 @@ Item_Random
 
 **Reward_#_Auto_Equip** *flag*: Item should be automatically equipped by the player.
 
-**Reward_#_Origin** *enum* (``World``, ``Admin``, ``Craft``, ``Nature``): Set the item origin. For example, setting the origin to ``Admin`` will cause items to spawn at full quality. Defaults to `Craft`.
+**Reward_#_Origin** :ref:`doc_data_eitemorigin`: Set the item origin. For example, setting the origin to ``Admin`` will cause items to spawn at full quality. Defaults to `Craft`.
 
 Hint
 ````

--- a/data/enum/eitemorigin.rst
+++ b/data/enum/eitemorigin.rst
@@ -1,0 +1,24 @@
+.. _doc_data_eitemorigin:
+
+EItemOrigin
+===========
+
+The EItemOrigin enumerated type is used when spawning items.
+
+Enumerators
+```````````
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+   
+   * - Named Value
+     - Description
+   * - ``World``
+     - Item origin is the world.
+   * - ``Admin``
+     - Item origin is an admin command.
+   * - ``Craft``
+     - Item origin is crafting.
+   * - ``Nature``
+     - Item origin is nature.

--- a/data/enum/index.rst
+++ b/data/enum/index.rst
@@ -5,11 +5,6 @@
 
 .. toctree::
 	:maxdepth: 1
+	:glob:
 	
-	ebatterymode
-	eitemrarity
-	eitemtype
-	elightingvision
-	enpcholiday
-	eobjectchart
-	eslottype
+	*

--- a/data/struct/index.rst
+++ b/data/struct/index.rst
@@ -5,5 +5,6 @@
 
 .. toctree::
 	:maxdepth: 1
+	:glob:
 	
-	playerspotlightconfig
+	*


### PR DESCRIPTION
Adds page for **EItemOrigin** type. TOCs for structs/enums will now auto-populate based on directory contents.