### PR TITLE
ItemCaliberAsset data table

### DIFF
--- a/assets/item-asset/caliber-asset.rst
+++ b/assets/item-asset/caliber-asset.rst
@@ -3,37 +3,208 @@
 Caliber Assets
 ==============
 
-This inherits the :ref:`ItemAsset <doc_item_asset_caliber>` class.
+The ItemCaliberAsset class is a base class that other classes are derived from. It is unusable on its own.
 
-Caliber Asset Properties
-------------------------
+Game Data File
+--------------
 
-**Aiming\_Movement\_Speed\_Multiplier** *float*: Character movement speed multiplier while the gun is aiming down sights.
+The ItemCaliberAsset class inherits properties from the :ref:`ItemAsset <doc_item_asset_caliber>` class.
 
-**Aiming\_Recoil\_Multiplier** *float*: Recoil magnitude multiplier while the gun is aiming down sights.
+Properties
+``````````
 
-**Aim\_Duration\_Multiplier** *float*: Multiplier for ``Aim_In_Duration`` value.
+.. list-table::
+   :widths: 40 40 20
+   :header-rows: 1
+   
+   * - Property Name
+     - Type
+     - Default Value
+   * - :ref:`Aiming_Movement_Speed_Multiplier <doc_item_asset_caliber:aiming_movement_speed_multiplier>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Aiming_Recoil_Multiplier <doc_item_asset_caliber:aiming_recoil_multiplier>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Aim_Duration_Multiplier <doc_item_asset_caliber:aim_duration_multiplier>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Ballistic_Damage_Multiplier <doc_item_asset_caliber:ballistic_damage_multiplier>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - See description
+   * - :ref:`Calibers <doc_item_asset_caliber:calibers>`
+     - :ref:`uint8 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Caliber_# <doc_item_asset_caliber:caliber_#>`
+     - :ref:`uint16 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Damage <doc_item_asset_caliber:damage>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - *deprecated*
+   * - :ref:`Destroy_Attachment_Colliders <doc_item_asset_caliber:destroy_attachment_colliders>`
+     - :ref:`bool <doc_data_builtin_types>`
+     - ``true``
+   * - :ref:`Firerate <doc_item_asset_caliber:firerate>`
+     - :ref:`uint8 <doc_data_builtin_types>`
+     - ``0``
+   * - :ref:`Paintable <doc_item_asset_caliber:paintable>`
+     - :ref:`flag <doc_data_flag>`
+     - 
+   * - :ref:`Recoil_X <doc_item_asset_caliber:recoil_x>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Recoil_Y <doc_item_asset_caliber:recoil_y>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Shake <doc_item_asset_caliber:shake>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Spread <doc_item_asset_caliber:spread>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
+   * - :ref:`Sway <doc_item_asset_caliber:sway>`
+     - :ref:`float32 <doc_data_builtin_types>`
+     - ``1``
 
-**Ballistic_Damage_Multiplier** *float*: Multiplier on damage. Defaults to the value used for the Damage property.
+Property Descriptions
+`````````````````````
 
-**Calibers** *uint16*: Total amount of unique calibers.
+.. _doc_item_asset_caliber:aiming_movement_speed_multiplier:
 
-**Caliber\_#** *uint16*: Caliber ID for acceptable attachment compatibility.
+Aiming_Movement_Speed_Multiplier :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-**Damage** *float*: Multiplier on damage. Defaults to 1. Deprecated in favor of Ballistic_Damage_Multiplier.
+Multiplier on character movement speed while aiming down sights.
 
-**Destroy_Attachment_Colliders** *bool*: If false, colliders are not destroyed when the base gun item's colliders are destroyed. Kept for compatibility if mods relied on attachments having colliders, but it is not recommended because there have been reports of low performance with some mods having complex colliders on every modded attachment in the level. Defaults to true.
+----
 
-**Firerate** *byte*: Amount to decrease ranged weapon's firerate value by. Decreasing by a larger value will allow the ranged weapon to fire more often.
+.. _doc_item_asset_caliber:aiming_recoil_multiplier:
 
-**Paintable** *flag*: Specified if the attachment should be affected by Steam Economy ranged weapon skins that include support for attachments.
+Aiming_Recoil_Multiplier :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-**Recoil_X** *float*: Multiplier on horizontal recoil.
+Multiplier on recoil magnitude while aiming down sights.
 
-**Recoil_Y** *float*: Multiplier on vertical recoil.
+----
 
-**Shake** *float*: Multiplier on shake.
+.. _doc_item_asset_caliber:aim_duration_multiplier:
 
-**Spread** *float*: Multiplier on spread.
+Aim_Duration_Multiplier :ref:`float32 <doc_data_builtin_types>` ``1``
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-**Sway** *float*: Multiplier on sway.
+Multiplier on the value of :ref:`Aim_In_Duration <doc_item_asset_gun:aim_in_duration>` property available to the :ref:`ItemGunAsset <doc_item_asset_gun>` class.
+
+----
+
+.. _doc_item_asset_caliber:ballistic_damage_multiplier:
+
+Ballistic_Damage_Multiplier :ref:`float32 <doc_data_builtin_types>`
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on damage. Defaults to the value of the ``Damage`` property, or ``1`` if both properties are unset.
+
+----
+
+.. _doc_item_asset_caliber:caliber_#:
+
+Caliber_# :ref:`uint16 <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Legacy ID of a caliber to check for attachment compatibility. This property is used in conjunction with ``Calibers``, which determines how many instances of this property should be read by the game.
+
+When this property is unset, it will default to ``0``. When the ``Magazine_Calibers`` property is not greater than ``0``, this property will default to the value of ``Caliber``.
+
+----
+
+.. _doc_item_asset_caliber:calibers:
+
+Calibers :ref:`uint8 <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Set the length of the array containing the calibers for attachment compatibility. This property is used in conjunction with the ``Caliber_#`` property, and the value of ``Calibers`` should be equal to the number of instances of ``Caliber_#``.
+
+----
+
+.. _doc_item_asset_caliber:damage:
+
+Damage :ref:`float32 <doc_data_builtin_types>`
+::::::::::::::::::::::::::::::::::::::::::::::
+
+.. deprecated:: 3.27.0.0
+   Use ``Ballistic_Damage_Multiplier`` instead.
+
+Maintained for backwards compatibility. If both this property and ``Ballistic_Damage_Multiplier`` have been set, the latter's value is used.
+
+----
+
+.. _doc_item_asset_caliber:destroy_attachment_colliders:
+
+Destroy_Attachment_Colliders :ref:`bool <doc_data_builtin_types>` ``true``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+When ``false``, colliders are not destroyed when the attached ranged weapon's colliders are destroyed. This property exists for backwards compatibility with mods that may have relied on attachments having colliders, but using this property is not recommended.
+
+.. caution:: Mods with complex colliders on their custom attachments are frequently reported as causing low performance issues for players. It is recommended that your custom attachments do not rely on having colliders.
+
+----
+
+.. _doc_item_asset_caliber:firerate:
+
+Firerate :ref:`uint8 <doc_data_builtin_types>` ``0``
+::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+The value of the attached ranged weapon's :ref:`Firerate <doc_item_asset_gun:firerate>` property is reduced by the value of this property. A larger decrease will allow for the ranged weapon to fire more often.
+
+----
+
+.. _doc_item_asset_caliber:paintable:
+
+Paintable :ref:`flag <doc_data_flag>`
+:::::::::::::::::::::::::::::::::::::
+
+When this flag is included, the attachment should be affected by Steam Economy skins that include support for skinning attachments.
+
+----
+
+.. _doc_item_asset_caliber:recoil_x:
+
+Recoil_X :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on horizontal recoil.
+
+----
+
+.. _doc_item_asset_caliber:recoil_y:
+
+Recoil_Y :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on vertical recoil.
+
+----
+
+.. _doc_item_asset_caliber:shake:
+
+Shake :ref:`float32 <doc_data_builtin_types>` ``1``
+:::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on shake.
+
+----
+
+.. _doc_item_asset_caliber:spread:
+
+Spread :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on bullet spread.
+
+----
+
+.. _doc_item_asset_caliber:sway:
+
+Sway :ref:`float32 <doc_data_builtin_types>` ``1``
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Multiplier on scope sway.

--- a/assets/item-asset/gun-asset.rst
+++ b/assets/item-asset/gun-asset.rst
@@ -96,7 +96,7 @@ Ranged weapons inherit properties from the :ref:`ItemWeaponAsset <doc_item_asset
    * - :ref:`ItemAsset <doc_item_asset_intro>`
      - :ref:`Useable <doc_item_asset_intro:useable>`
      - ``Gun``
-   * - :ref:`WeaponAsset <doc_item_asset_intro>`
+   * - :ref:`ItemWeaponAsset <doc_item_asset_intro>`
      - :ref:`Range <doc_item_asset_weapon:range>`
      - 
 


### PR DESCRIPTION
Rewrites the Caliber Assets doc to use data table format for properties.

- [Caliber Assets](https://unturned--319.org.readthedocs.build/en/319/assets/item-asset/caliber-asset.html)
- [Gun Assets](https://unturned--319.org.readthedocs.build/en/319/assets/item-asset/gun-asset.html#game-data-file) (minor fix)