### PR TITLE
UnturnedLexer module

### DIFF
--- a/_extensions/unturned_lexer.py
+++ b/_extensions/unturned_lexer.py
@@ -1,0 +1,36 @@
+"""
+    unturned_lexer
+    ~~~~~~~~~~~~~~
+    Lexer for Unturned's .dat and .asset files.
+    https://pygments.org/docs/lexerdevelopment/
+"""
+
+__all__ = ['UnturnedLexer']
+
+from pygments.lexer import RegexLexer, bygroups
+from pygments.token import *
+
+class UnturnedLexer(RegexLexer):
+    name = 'UnturnedDat'
+    aliases = ['unturned']
+    filenames = ['*.asset', '*.dat']
+
+    tokens = {
+        'root': [
+            (r'("(?:\\.|[^"])*")(?:(\s*)(//.*)$)?', bygroups(String, Whitespace, Comment)), # Quoted key or value – optionally, a comment (inline) can be matched too.
+            (r'(^\s*)(//.*)$', bygroups(Whitespace, Comment)), # Comment (newline).
+            (r'(^\s*)(\w+)\b', bygroups(Whitespace, Name.Class)), # "Key" in a key-value pair, or a "flag".
+            (r'(^\s*)([\[\]\{\}])', bygroups(Whitespace, Name.Decorator)), # Brackets (dictionaries, lists).
+
+            (r'true|false', Name.Builtin), # Boolean.
+            (r'(#)([a-fA-F0-9]{6})', bygroups(Operator, Number)), # Color (hex triplet).
+            (r'[-,\(\)]', Operator), # Punctuation for numbers (negatives, commas, vector3).
+            (r'\b(\d+\.?\d*|\d*\.?\d+)\b', Number), # Number (integer, float) – this doesn't capture values such as "1." or ".1" currently. It could be changed to do so, but we may need to make separate rules for integers and floats, and possibly GUIDs as well.
+
+            (r'\S+', Text), # Match remaining non-whitespace.
+            (r'\n|\s+', Whitespace), # Match remaining whitespace – line breaks must be matched first, otherwise \s+ is too greedy and breaks preceding rules relying on whitespace.
+        ]
+    }
+
+def setup(sphinx):
+    sphinx.add_lexer("unturned", UnturnedLexer)

--- a/assets/crafting-blacklist-asset.rst
+++ b/assets/crafting-blacklist-asset.rst
@@ -9,7 +9,7 @@ Prevents specific items or blueprints from being used while crafting. They are h
 
 **Input_Items** array of Item :ref:`Asset Pointers <doc_data_assetptr>`: Any blueprints consuming these items cannot be crafted. For example (blacklisted items are highlighted):
 
-.. code-block:: cpp
+.. code-block:: unturned
 	:linenos:
 	:emphasize-lines: 4, 7-10, 13-16
 
@@ -35,7 +35,7 @@ Prevents specific items or blueprints from being used while crafting. They are h
 
 **Blueprints** array: Prevent specific individual blueprints from being crafted. Each entry has an ``Item`` :ref:`Asset Pointer <doc_data_assetptr>` and ``Blueprint`` index. For example, to prevent the Chef Hat from being salvaged:
 
-.. code-block:: text
+.. code-block:: unturned
 
 	Blueprints
 	[

--- a/assets/item-asset/gun-asset.rst
+++ b/assets/item-asset/gun-asset.rst
@@ -590,7 +590,7 @@ When this property is unset, it will default to ``0``. When the ``Attachment_Cal
 
 For example, a valid configuration for a ranged weapon's calibers could be:
 
-.. code-block:: text
+.. code-block:: unturned
 
   Attachment_Calibers 2
   Attachment_Caliber_0 1

--- a/conf.py
+++ b/conf.py
@@ -1,16 +1,20 @@
 # Configuration file for the Sphinx documentation builder.
+#
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import sys, os
 
 # -- Project information
 
 project = "Unturned"
-copyright = '2023, Smartly Dressed Games'
-author = 'Smartly Dressed Games'
+copyright = "2023, Smartly Dressed Games"
+author = "Smartly Dressed Games"
 
-release = '0.1'
-version = '0.1.0'
+release = "0.1"
+version = "0.1.0"
 
 # -- General configuration
-
+sys.path.append(os.path.abspath("_extensions")) # also find extensions within this directory
 extensions = [
     'sphinx.ext.duration',
     'sphinx.ext.doctest',
@@ -20,6 +24,8 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinxext.opengraph', # OpenGraph support (e.g., URLs posted onto our Discourse forum will appear as OneBox embeds)
     'sphinx_rtd_theme', # "Read the Docs Sphinx Theme" https://sphinx-rtd-theme.readthedocs.io/en/stable/index.html
+    # -- Locally-installed modules
+    'unturned_lexer',
 ]
 
 autosectionlabel_prefix_document = True # make sure explicit target is unique


### PR DESCRIPTION
Following up on #311, this adds a custom lexer for UnturnedDat files (`.asset` and `.dat`). There's a couple shortcomings, which I've added as comments within the lexer.

Notably, the rule for matching numbers doesn't match values like `.1`. This could be changed, but we may need separate rules for integers and floats (possibly GUIDs). Also – lists/dictionaries that don't require key-value pairs (e.g., CraftingBlacklistAsset supports listing GUIDs without a key) will see those values matched as keys.

Extensions can loaded locally from `_extensions`. Our custom lexer is `unturned_lexer.py`, and is usable within code-blocks with `unturned`. We could add other aliases such as unturnedasset, unturneddat, dat, etc. I've updated a couple code-blocks to use the lexer.

- https://unturned--322.org.readthedocs.build/en/322/assets/crafting-blacklist-asset.html
- https://unturned--322.org.readthedocs.build/en/322/assets/item-asset/gun-asset.html#attachment-caliber-uint16

![image](https://github.com/SmartlyDressedGames/Unturned-Docs/assets/7608445/ad92f2a1-cec3-45ea-9381-72f7f9376ea7)