### PR TITLE
Fix links to Color datatype

### DIFF
--- a/assets/item-asset/glasses-asset.rst
+++ b/assets/item-asset/glasses-asset.rst
@@ -25,7 +25,7 @@ Glasses Asset Properties
 
 **Nightvision_Allowed_In_ThirdPerson** *bool*: If ``true``, nightvision works in third-person, not just first-person. Defaults to ``false`` for backwards compatibility. Vanilla nightvision has this set to true.
 
-**Nightvision_Color** :ref:`color <doc_data_file_format>`: Overrides the default color when using ``Vision Military``. This property supports using legacy color parsing.
+**Nightvision_Color** :ref:`color <doc_data_color>`: Overrides the default color when using ``Vision Military``. This property supports using legacy color parsing.
 
 **Nightvision_Fog_Intensity** *float*: Intensity of fog while nightvision is active.
 

--- a/assets/item-asset/sight-asset.rst
+++ b/assets/item-asset/sight-asset.rst
@@ -46,7 +46,7 @@ Properties
      - :ref:`flag <doc_data_flag>`
      - 
    * - :ref:`Nightvision_Color <doc_item_asset_sight:nightvision_color>`
-     - :ref:`color <doc_data_file_format>`
+     - :ref:`color <doc_data_color>`
      - See description
    * - :ref:`Nightvision_Fog_Intensity <doc_item_asset_sight:nightvision_fog_intensity>`
      - :ref:`float32 <doc_data_builtin_types>`
@@ -95,7 +95,7 @@ DistanceMarker Dictionary
      - :ref:`bool <doc_data_builtin_types>`
      - ``true``
    * - :ref:`Color <doc_item_asset_sight:distancemarker_color>`
-     - :ref:`color <doc_data_file_format>`
+     - :ref:`color <doc_data_color>`
      - ``black``
 
 .. _doc_item_asset_sight:eside_enumeration:
@@ -252,7 +252,7 @@ If true, a label with ``Distance`` text is shown next to the horizontal line mar
 
 .. _doc_item_asset_sight:distancemarker_color:
 
-Color :ref:`color <doc_data_file_format>` ``black``
-:::::::::::::::::::::::::::::::::::::::::::::::::::
+Color :ref:`color <doc_data_color>` ``black``
+:::::::::::::::::::::::::::::::::::::::::::::
 
 Override the color of the horizontal line and text.

--- a/data/struct/playerspotlightconfig.rst
+++ b/data/struct/playerspotlightconfig.rst
@@ -28,7 +28,7 @@ Properties
      - :ref:`float32 <doc_data_builtin_types>`
      - ``1.3``
    * - :ref:`SpotLight_Color <doc_data_playerspotlightconfig:spotlight_color>`
-     - :ref:`color <doc_data_file_format>`
+     - :ref:`color <doc_data_color>`
      - ``#f5df93``
 
 Property Descriptions


### PR DESCRIPTION
Some links were targeting the old location for this info. I've updated them to the dedicated Color datatype doc.