### PR TITLE
Load custom CSS

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1,0 +1,15 @@
+/**
+ * Custom tweaks to the Read the Docs theme.
+ */
+
+/* Wrap table contents for large screens. */
+/* COMMENTED OUT -- Reconsidering best way to implement wrapping for tables.
+ * Maybe this should only apply to a custom table class (a la, .wrapping)
+ * Additionally, maybe tables should always be forced to full body width
+
+@media screen and (min-width: 769px) {
+	.wy-table-responsive { overflow: visible; }
+	.wy-table-responsive table td { white-space: normal; }
+}
+
+*/

--- a/conf.py
+++ b/conf.py
@@ -48,5 +48,14 @@ html_theme_options = {
     'collapse_navigation': True,
 }
 
+# These folders are copied to the documentation's HTML output
+html_static_path = ["_static"]
+
+# These paths are either relative to html_static_path
+# or fully qualified paths (e.g. https://...)
+html_css_files = [
+    'css/custom.css',
+]
+
 # -- Options for EPUB output
 epub_show_urls = 'footnote'


### PR DESCRIPTION
conf.py would now be able to load custom CSS and JS from **_static**.

Currently, **css/custom.css** is loaded. The only styling rule is to add word-wrapping to tables (on desktop monitors, i.e. where horizontal scrollbars are undesirable).