### PR TITLE
Update current introductory articles

### DIFF
--- a/about/getting-started.rst
+++ b/about/getting-started.rst
@@ -8,7 +8,7 @@ To get started with creating mods for *Unturned*, certain tools need to be downl
 Installing Unturned
 -------------------
 
-*Unturned* must be downloaded in order to create and upload mods. The game can be downloaded from `Steam <https://store.steampowered.com/app/304930/>`_. If you are using SteamCMD, its app ID is ``304930``.
+*Unturned* must be downloaded in order to create and upload mods. The game can be downloaded from `Steam <https://store.steampowered.com/app/304930/>`_.
 
 Not only do the game files include tools necessary for creating custom content, but the game's official assets can also be used as an example when creating your own items, objects, or other assets.
 
@@ -63,7 +63,7 @@ Text editors
 
 A text editor (e.g., Notepad) or a code editor (e.g., Notepad++ or Visual Studio Code) is required to write the game data files used by assets. Code editors often include other useful tools, such as being able to search-and-replace content across multiple files at once.
 
-We *do not* recommend using a word processor, as these can add unwanted characters when not used properly.
+We *do not* recommend using a word processor (e.g., Microsoft Word, LibreOffice, or WordPad). Such programs are not intended intended for writing plain text files, and it is easy to accidentally add unwanted characters when not used properly.
 
 If you are unsure what you should use, Notepad comes installed on all Windows systems by default, and lacks any additional tools or features that (while helpful) may be confusing for an inexperienced user.
 

--- a/about/getting-started.rst
+++ b/about/getting-started.rst
@@ -3,6 +3,18 @@
 Getting Started
 ===============
 
+To get started with creating mods for *Unturned*, certain tools need to be downloaded first. This article provides a walkthrough for downloading these tools.
+
+Installing Unturned
+-------------------
+
+*Unturned* must be downloaded in order to create and upload mods. The game can be downloaded from `Steam <https://store.steampowered.com/app/304930/>`_. If you are using SteamCMD, its app ID is ``304930``.
+
+Not only do the game files include tools necessary for creating custom content, but the game's official assets can also be used as an example when creating your own items, objects, or other assets.
+
+Installing Unity
+----------------
+
 Installing the Unity Editor is required for exporting custom content into the game. Most 2021.3 LTS version should be compatible; Unturned currently uses 2021.3.29f1. `View Download Links <https://unity.com/releases/editor/qa/lts-releases?version=2021.3>`_
 
 Once Unity is installed, a project can be created to house custom content. At this point, it is recommended to import Unturned's provided Unity packages.
@@ -40,3 +52,27 @@ This package contains vanilla content examples, and several useful prefabs:
 - ``Resources/Characters/Preview.prefab`` is helpful for previewing clothes.
 
 .. warning:: Custom content should not be placed into the CoreMasterBundle directory. Instead, create a separate directory to house your custom content.
+
+Other Tools
+-----------
+
+Modders will need a few more tools on hand to create custom content.
+
+Text editors
+````````````
+
+A text editor (e.g., Notepad) or a code editor (e.g., Notepad++ or Visual Studio Code) is required to write the game data files used by assets. Code editors often include other useful tools, such as being able to search-and-replace content across multiple files at once.
+
+We *do not* recommend using a word processor, as these can add unwanted characters when not used properly.
+
+If you are unsure what you should use, Notepad comes installed on all Windows systems by default, and lacks any additional tools or features that (while helpful) may be confusing for an inexperienced user.
+
+Image editing software
+``````````````````````
+
+To create custom textures for your modded content – such as for new shirts or pants, materials for custom objects, or 2D effects – you will need an image editing software that supports transparency. Some free image editors include Paint.NET, GIMP, and Krita.
+
+Blender
+```````
+
+A 3D modeling tool such as Blender is required to create custom models (and animations). Blender is the same tool we use for *Unturned*, although it is not strictly required.

--- a/about/launch-options.rst
+++ b/about/launch-options.rst
@@ -1,22 +1,24 @@
-.. _doc_commandline:
+.. _doc_launch_options:
 
-Command-line Arguments
-======================
+Launch Options
+==============
 
-You can add command-line arguments within Steam:
+Launch options can be added to *Unturned* to change certain game settings before running the game. This allows for recovering from certain problems (such as an unwanted resolution or UI scale), troubleshooting a wide range of issues, or toggling settings not available from in-game.
 
-#. Right-click Unturned in your Steam Library
+This article lists the launch options available for *Unturned*. You can `add launch options <https://help.steampowered.com/en/faqs/view/7D01-D2DD-D75E-2955>`_ through your Steam Library.
 
-#. Select Properties... > General
+#. Right-click **Unturned** in your Steam Library.
 
-#. Find the Launch Options field
+#. Select the **Properties...** button.
 
-#. Type options separated by spaces. For example "-FallbackGizmos -Width=1920 -Height=1080" will enable the FallbackGizmos flag, set Width to 1920 and set Height to 1080.
+#. On the **General** tan, find the **Launch Options** field near the bottom.
 
-Game options
+#. Type options separated by spaces. For example, ``-TimeOverlay -Width=1920 -Height=1080`` will enable the TimeOverlay flag, set Width to 1920, and set Height to 1080.
+
+Game Options
 ------------
 
-Some command-line arguments are primarily intended for use with the Unturned Dedicated Server app.
+Some of the launch options are primarily intended for use with the Unturned Dedicated Server tool.
 
 **+connect**: Connect to a server, in the format of ``+connect <ip address>:<port>``.
 
@@ -36,7 +38,7 @@ Some command-line arguments are primarily intended for use with the Unturned Ded
 
 **-GameSense**: GameSense integration.
 
-**-Glazier=** *enum* (``IMGUI``): Use the legacy IMGUI rather than the default uGUI.
+**-Glazier=** *enum* (``IMGUI``, ``UIToolkit``): Use a different UI system instead of the default uGUI. Accepted values are ``IMGUI`` (legacy) and ``UIToolkit`` (experimental). For more information, refer to: :ref:`doc_glazier`.
 
 **-h** *int*: Alias of ``-height``.
 
@@ -90,7 +92,7 @@ Some command-line arguments are primarily intended for use with the Unturned Ded
 
 **-width** *int*: Override in-game resolution width.
 
-Unity options
+Unity Options
 -------------
 
 Unity's built-in command-line arguments take priority over *Unturned*'s equivalents. Some of the more relevant Unity arguments are mentioned below, but the rest can be found in the `Unity User Manual <https://docs.unity3d.com/2019.4/Documentation/Manual/PlayerCommandLineArguments.html>`_.

--- a/assets/item-asset/gun-asset.rst
+++ b/assets/item-asset/gun-asset.rst
@@ -1261,7 +1261,7 @@ Spread_Hip :ref:`float32 <doc_data_builtin_types>`
 .. deprecated:: 3.22.20.0
    Use ``Spread_Angle_Degrees`` instead.
 
-Maintained for backwards compatibility. Running the game with the ``-ValidateAssets`` :ref:`launch option <doc_commandline>` will log the equivalent ``Spread_Angle_Degrees`` value.
+Maintained for backwards compatibility. Running the game with the ``-ValidateAssets`` :ref:`launch option <doc_launch_options>` will log the equivalent ``Spread_Angle_Degrees`` value.
 
 ----
 

--- a/index.rst
+++ b/index.rst
@@ -9,8 +9,8 @@
 	:maxdepth: 1
 	:caption: About
 
-	about/command-line
 	about/getting-started
+	about/launch-options
 
 .. First section has articles on assets (in general).
 	Second section lists asset types, alphabetically.
@@ -106,18 +106,16 @@
 Unturned Documentation
 ======================
 
-This repository exists to document `Unturned <https://store.steampowered.com/app/304930>`_'s modding features going forward. Originally map and asset documentation was created through Steam Guides. The main guide with links to related guides can be found here: `Workshop: Creating, Publishing & Updating <https://steamcommunity.com/sharedfiles/filedetails/?id=460136012>`_.
+Welcome to the official documentation for `Unturned <https://store.steampowered.com/app/304930>`_'s modding and server hosting features! To navigate, use the table of contents in the sidebar or the search function in the top-left corner.
+
+A lot of our older documentation was scattered between YouTube videos and Steam Guides. The main Steam Guide with links to related guides can be found here: `Workshop: Creating, Publishing & Updating <https://steamcommunity.com/sharedfiles/filedetails/?id=460136012>`_. Note that most of these older guides are outdated.
 
 Upcoming Features
 -----------------
 
-You can find modding features under consideration on this Trello board: `Unturned Roadmap <https://trello.com/b/gpe4zlW3/unturned-roadmap>`_
+You can find modding features under consideration on this Trello board: `Unturned Roadmap <https://trello.com/b/gpe4zlW3/unturned-roadmap>`_. The cards on the board aren't ordered in any particular way. i.e., they do not dictate the order of updates.
 
-The cards on the board aren't ordered in any particular way. i.e., they do not dictate the order of updates.
-
-Miscellaneous requests and tasks that pop up take priority over the roadmap, so it may go a while between progress updates. For example, work for curated maps often takes priority.
-
-Several high-priority ideas that don't yet have a solid plan, like car physics improvements or a crafting revamp, aren't listed on the board.
+Miscellaneous requests and tasks that may pop up take priority over the roadmap, so it may go a while between progress updates. For example, work for curated maps often takes priority. Several high-priority ideas that don't yet have a solid plan, like a crafting revamp, aren't listed on the board.
 
 Video Tutorials
 ---------------


### PR DESCRIPTION
- Rename to "Launch Options". Place after Getting Started in the TOC.
- Update info for Getting Started. A few sections on: installing Unturned; and other tools such as text editors, image editors, and Blender.
- Tweaks the "Upcoming Features" section in the index. It's mostly the same, although I removed the bit about "car physics improvements" since that's currently in development.