### PR TITLE
Update links to Unturned Wiki

### DIFF
--- a/assets/item-asset/arrest-end-asset.rst
+++ b/assets/item-asset/arrest-end-asset.rst
@@ -3,7 +3,7 @@
 Arrest End Assets
 =================
 
-The ItemArrestEndAsset class is used for "releaser" items, which can remove a corresponding ":ref:`catcher <doc_item_asset_arrest_start>`" item that is restraining a player. An example of a vanilla releaser is the `Handcuffs Key <https://wiki.smartlydressedgames.com/wiki/Handcuffs_Key>`_.
+The ItemArrestEndAsset class is used for "releaser" items, which can remove a corresponding ":ref:`catcher <doc_item_asset_arrest_start>`" item that is restraining a player. An example of a vanilla releaser is the `Handcuffs Key <https://unturned.wiki.gg/wiki/Handcuffs_Key>`_.
 
 Game Data File
 --------------

--- a/assets/item-asset/arrest-start-asset.rst
+++ b/assets/item-asset/arrest-start-asset.rst
@@ -3,7 +3,7 @@
 Arrest Start Assets
 ===================
 
-The ItemArrestStartAsset class is used for "catcher" items, which can restrain a player. Its sister item, the ":ref:`releaser <doc_item_asset_arrest_start>`", can be used to unlock restraints. Some examples of vanilla catchers include the `Handcuffs <https://wiki.smartlydressedgames.com/wiki/Handcuffs>`_ and `Cable Tie <https://wiki.smartlydressedgames.com/wiki/Cable_Tie>`_.
+The ItemArrestStartAsset class is used for "catcher" items, which can restrain a player. Its sister item, the ":ref:`releaser <doc_item_asset_arrest_start>`", can be used to unlock restraints. Some examples of vanilla catchers include the `Handcuffs <https://unturned.wiki.gg/wiki/Handcuffs>`_ and `Cable Tie <https://unturned.wiki.gg/wiki/Cable_Tie>`_.
 
 Game Data File
 --------------

--- a/assets/item-asset/barricade-asset.rst
+++ b/assets/item-asset/barricade-asset.rst
@@ -31,7 +31,7 @@ Barricade Asset Properties
 
 **Allow_Placement_On_Vehicle** *bool*: If true, this barricade can be placed on vehicles. Defaults to true, except when using ``Build Bed``, ``Build Sentry``, or ``Build Sentry_Freeform``.
 
-**Armor_Tier** *enum* (``Low``, ``High``): Barricade armor can either be low-tier or high-tier. Defaults to low-tier, except when the barricade's name contains the word "Metal". By default, barricades with low-tier armor take 100% of the damage they receive, while barricades with high-tier armor take 50% of the damage they receive. These multipliers can be configured in the `gameplay config <https://wiki.smartlydressedgames.com/wiki/Gameplay_config>`_.
+**Armor_Tier** *enum* (``Low``, ``High``): Barricade armor can either be low-tier or high-tier. Defaults to low-tier, except when the barricade's name contains the word "Metal". By default, barricades with low-tier armor take 100% of the damage they receive, while barricades with high-tier armor take 50% of the damage they receive. These multipliers can be configured in the `gameplay config <https://unturned.wiki.gg/wiki/Gameplay_config>`_.
 
 **Bypass_Claim** *flag*: Can be placed inside someone else's claimed area.
 
@@ -63,11 +63,11 @@ Barricade Asset Properties
 
 **Salvage_Duration_Multiplier** *float*: Multiplier on how long it takes to salvage this barricade. Setting this to a larger number will cause salvaging to take longer. Defaults to 1.
 
-**Unpickupable** *flag*: Disables the ability to pick up a placed barricade. For example, the `Horde Beacon <https://wiki.smartlydressedgames.com/wiki/Horde_Beacon>`_ uses this flag.
+**Unpickupable** *flag*: Disables the ability to pick up a placed barricade. For example, the `Horde Beacon <https://unturned.wiki.gg/wiki/Horde_Beacon>`_ uses this flag.
 
-**Unrepairable** *flag*: Cannot be repaired by a :ref:`MeleeAsset <doc_item_asset_melee>` with the ``Repair`` flag. For example, the `Blowtorch <https://wiki.smartlydressedgames.com/wiki/Blowtorch>`_ would not be able to repair this barricade.
+**Unrepairable** *flag*: Cannot be repaired by a :ref:`MeleeAsset <doc_item_asset_melee>` with the ``Repair`` flag. For example, the `Blowtorch <https://unturned.wiki.gg/wiki/Blowtorch>`_ would not be able to repair this barricade.
 
-**Unsalvageable** *flag*: Salvaging a damaged barricade yields no partial resources. For example, `small glass plates <https://wiki.smartlydressedgames.com/wiki/Small_Glass_Plate>`_ use this flag.
+**Unsalvageable** *flag*: Salvaging a damaged barricade yields no partial resources. For example, `small glass plates <https://unturned.wiki.gg/wiki/Small_Glass_Plate>`_ use this flag.
 
 **Unsaveable** *flag*: This barricade is excluded from being saved. For example, carepackages use this flag.
 

--- a/assets/item-asset/caliber-asset.rst
+++ b/assets/item-asset/caliber-asset.rst
@@ -8,7 +8,7 @@ The ItemCaliberAsset class is a base class that other classes are derived from. 
 Game Data File
 --------------
 
-The ItemCaliberAsset class inherits properties from the :ref:`ItemAsset <doc_item_asset_caliber>` class.
+The ItemCaliberAsset class inherits properties from the :ref:`ItemAsset <doc_item_asset_intro>` class.
 
 Properties
 ``````````

--- a/assets/item-asset/farm-asset.rst
+++ b/assets/item-asset/farm-asset.rst
@@ -23,7 +23,7 @@ Item Asset Properties
 Farm Asset Properties
 ---------------------
 
-**Affected_By_Agriculture_Skill** *bool*: If true, the amount of crops acquired when harvesting the plant is affected by the `Agriculture skill <https://wiki.smartlydressedgames.com/wiki/Skills>`_. Defaults to true.
+**Affected_By_Agriculture_Skill** *bool*: If true, the amount of crops acquired when harvesting the plant is affected by the `Agriculture skill <https://unturned.wiki.gg/wiki/Skills>`_. Defaults to true.
 
 **Allow_Fertilizer** *bool*: If true, allows the player to use fertilizer to fully grow the plant. Defaults to true.
 

--- a/assets/item-asset/gun-asset.rst
+++ b/assets/item-asset/gun-asset.rst
@@ -3,7 +3,7 @@
 Gun Assets
 ==========
 
-The ItemGunAsset class is used for ranged weapons (or "guns"), which can be used by players to deal damage. Some examples of vanilla ranged weapons include the `Eaglefire <https://wiki.smartlydressedgames.com/wiki/Eaglefire>`_ and `Crossbow <https://wiki.smartlydressedgames.com/wiki/Crossbow>`_.
+The ItemGunAsset class is used for ranged weapons (or "guns"), which can be used by players to deal damage. Some examples of vanilla ranged weapons include the `Eaglefire <https://unturned.wiki.gg/wiki/Eaglefire>`_ and `Crossbow <https://unturned.wiki.gg/wiki/Crossbow>`_.
 
 Unity Asset Bundle Contents
 ---------------------------
@@ -507,7 +507,7 @@ Action :ref:`EAction <doc_item_asset_gun:eaction>`
 
 The value of this property determines how the weapon functions when used, including whether it uses *ballistic projectiles*, or *physics projectiles*. Different properties are available to the weapon depending on the value of this property.
 
-Although most action mechanisms utilize ballistic projectiles, the ``Rocket`` action mechanism uses physics projectiles instead. Additionally, any projectiles from these weapons (e.g., the `Rocket Launcher <https://wiki.smartlydressedgames.com/wiki/Rocket_Launcher>`_) are explosive.
+Although most action mechanisms utilize ballistic projectiles, the ``Rocket`` action mechanism uses physics projectiles instead. Additionally, any projectiles from these weapons (e.g., the `Rocket Launcher <https://unturned.wiki.gg/wiki/Rocket_Launcher>`_) are explosive.
 
 To fire a weapon with the  ``String`` action mechanism, a player must be aiming down sights – unless a "Nock" GameObject has been added during its Unity setup.
 

--- a/assets/item-asset/structure-asset.rst
+++ b/assets/item-asset/structure-asset.rst
@@ -25,7 +25,7 @@ Item Asset Properties
 Structure Asset Properties
 --------------------------
 
-**Armor_Tier** *enum* (``Low``, ``High``): Armor is a multiplier on damage received. A structure's armor tier can either be low-tier or high-tier. By default, structures with low-tier armor take 100% of the damage they receive, while structures with high-tier armor take 50% of the damage they receive. These multipliers can be configured in the `gameplay config <https://wiki.smartlydressedgames.com/wiki/Gameplay_config>`_. Defaults to low-tier, except when the structure's name contains the word "Metal" or "Brick".
+**Armor_Tier** *enum* (``Low``, ``High``): Armor is a multiplier on damage received. A structure's armor tier can either be low-tier or high-tier. By default, structures with low-tier armor take 100% of the damage they receive, while structures with high-tier armor take 50% of the damage they receive. These multipliers can be configured in the `gameplay config <https://unturned.wiki.gg/wiki/Gameplay_config>`_. Defaults to low-tier, except when the structure's name contains the word "Metal" or "Brick".
 
 **Can_Be_Damaged** *bool*: If true, this structure can be damaged. Defaults to true.
 
@@ -53,7 +53,7 @@ Structure Asset Properties
 
 **Unpickupable** *flag*: Disables the ability to pick up a placed structure.
 
-**Unrepairable** *flag*: Cannot be repaired by a :ref:`MeleeAsset <doc_item_asset_melee>` with the ``Repair`` flag. For example, the `Blowtorch <https://wiki.smartlydressedgames.com/wiki/Blowtorch>`_ would not be able to repair this structure.
+**Unrepairable** *flag*: Cannot be repaired by a :ref:`MeleeAsset <doc_item_asset_melee>` with the ``Repair`` flag. For example, the `Blowtorch <https://unturned.wiki.gg/wiki/Blowtorch>`_ would not be able to repair this structure.
 
 **Unsalvageable** *flag*: Salvaging a damaged structure yields no partial resources.
 

--- a/assets/item-asset/trap-asset.rst
+++ b/assets/item-asset/trap-asset.rst
@@ -27,7 +27,7 @@ Trap Asset Properties
 
 **Barricade_Damage** *float*: Damage dealt to barricades caught within the area-of-effect explosion.
 
-**Broken** *flag*: Players who trigger the trap will be inflicted with the `Broken Bones <https://wiki.smartlydressedgames.com/wiki/Broken%20Bones>`_ status effect.
+**Broken** *flag*: Players who trigger the trap will be inflicted with the `Broken Bones <https://unturned.wiki.gg/wiki/Broken_Bones>`_ status effect.
 
 **Damage_Tires** *flag*: This trap can pop the tires of vehicles that drive over it.
 


### PR DESCRIPTION
Updates all _wiki.smartlydressedgames.com_ links to instead point to [unturned.wiki.gg](https://unturned.wiki.gg/). (E.g., the [gun assets page](https://unturned--330.org.readthedocs.build/en/330/assets/item-asset/gun-asset.html) had a couple links.)

Misc. fix for an internal link (went to wrong page).