### PR TITLE
Clarify how Item Slots work

### DIFF
--- a/assets/item-asset/melee-asset.rst
+++ b/assets/item-asset/melee-asset.rst
@@ -16,7 +16,7 @@ Item Asset Properties
 
 **Useable** *enum* (``Melee``)
 
-**Slot** *enum* (``Primary``, ``Secondary``, ``Tertiary``, ``Any``)
+**Slot** :ref:`ESlotType <doc_data_eslottype>` (``None``, ``Primary``, ``Secondary``, ``Any``): Most melee weapons, including vanilla items, use ``Secondary``. This allows the weapon to be used from either the character's primary or secondary slot.
 
 **ID** *uint16*: Must be a unique identifier.
 

--- a/data/enum/eslottype.rst
+++ b/data/enum/eslottype.rst
@@ -3,7 +3,7 @@
 ESlotType
 =========
 
-The ESlotType enumerated type is used by equippable items. Some assets may only support using specific enumerators.
+The ESlotType enumerated type is used for item placement in displays or on characters, and determines which item slot(s) an equippable item can be placed in. Some assets may only support using specific enumerators.
 
 Enumerators
 ```````````
@@ -15,12 +15,12 @@ Enumerators
    * - Named Value
      - Description
    * - ``None``
-     - Does not correspond to any item slot.
+     - Does not correspond to any slot. Equippables can be hotkeyed.
    * - ``Primary``
-     - Corresponds to the "Primary" item slot.
+     - Corresponds to the "Primary" slot. Equippables can be used from the primary slot.
    * - ``Secondary``
-     - Corresponds to the "Secondary" item slot.
+     - Corresponds to the "Secondary" slot. Equippables from the primary or secondary slot.
    * - ``Tertiary``
-     - Corresponds to the "Tertiary" item slot.
+     - Corresponds to the "Tertiary" slot. This is only used by NPCs.
    * - ``Any``
-     - Corresponds to any/all item slots.
+     - Corresponds to any/all item slots. Equippables can be used from any slot, or hotkeyed.


### PR DESCRIPTION
ESlotType provides more info about expected behavior. (Previously only mentioned in ItemAsset, but reasonable to also include here.)

ItemMeleeAsset mentions ``None`` (instead of the unimplemented ``Tertiary``) and links back to ESlotType. Mentions that the typical value is ``Secondary``.