### PR TITLE
Fix codeblocks instead being italicized

### DIFF
--- a/assets/npc-asset/dialogue-asset.rst
+++ b/assets/npc-asset/dialogue-asset.rst
@@ -29,7 +29,7 @@ Properties pertaining to dialogue performed by the NPC. Dialogue can utilize con
 Responses
 ---------
 
-Properties pertaining to dialogue available to the player. Dialogue can utilize conditions and rewards. Responses are only visible when conditions are met, and can grant rewards when selected. These are prefixed with `Response_#_`. For example, `Response_0_Reward_0_Type Quest`. For more information, refer to the documentation for :ref:`Conditions <doc_npc_asset_conditions>` and :ref:`Rewards <doc_npc_asset_rewards>` respectively.
+Properties pertaining to dialogue available to the player. Dialogue can utilize conditions and rewards. Responses are only visible when conditions are met, and can grant rewards when selected. These are prefixed with ``Response_#_``. For example, `Response_0_Reward_0_Type Quest`. For more information, refer to the documentation for :ref:`Conditions <doc_npc_asset_conditions>` and :ref:`Rewards <doc_npc_asset_rewards>` respectively.
 
 **Responses** *byte*: Total number of possible responses.
 

--- a/assets/npc-asset/rewards-list-asset.rst
+++ b/assets/npc-asset/rewards-list-asset.rst
@@ -7,7 +7,7 @@ Rewards List Assets
 
 **Type** *enum* (``RewardsList``)
 
-The `Rewards_List_Asset` NPC reward type can either grant a rewards list asset directly, or a :ref:`Spawn Table Asset <doc_assets_spawn>` which resolves to the final asset. This could be used, for example, to randomly select one of several rewards list assets which then grants the player a gun along with related ammo items.
+The ``Rewards_List_Asset`` NPC reward type can either grant a rewards list asset directly, or a :ref:`Spawn Table Asset <doc_assets_spawn>` which resolves to the final asset. This could be used, for example, to randomly select one of several rewards list assets which then grants the player a gun along with related ammo items.
 
 A `Rewards List Volume` placed in the level editor can also reference a rewards list asset, and will grant the rewards if the conditions are met when a player enters the volume.
 

--- a/assets/npc-asset/rewards.rst
+++ b/assets/npc-asset/rewards.rst
@@ -30,9 +30,9 @@ Flag_Math
 
 **Reward_#_A_ID** *uint16*: ID of flag to apply math to.
 
-**Reward_#_B_ID** *uint16*: ID of flag containing value to be applied mathematically. If not specified then `B_Value` is used instead.
+**Reward_#_B_ID** *uint16*: ID of flag containing value to be applied mathematically. If not specified then ``B_Value`` is used instead.
 
-**Reward_#_B_Value** *int16*: default value to be applied mathematically if flag B has not been set on the player or if `B_ID` is zero.
+**Reward_#_B_Value** *int16*: default value to be applied mathematically if flag B has not been set on the player or if ``B_ID`` is zero.
 
 **Reward_#_Operation** *enum* (``Addition``, ``Assign``, ``Division``, ``Modulo``, ``Multiplication``, ``Subtraction``): For example, using the Addition operation would set A to the value of A + B.
 
@@ -125,7 +125,7 @@ Item
 
 **Reward_#_Magazine** *uint16*: Override for the magazine attachment that should be attached to the item reward.
 
-**Reward_#_Origin** :ref:`doc_data_eitemorigin`: Set the item origin. For example, setting the origin to ``Admin`` will cause items to spawn at full quality. Defaults to `Craft`.
+**Reward_#_Origin** :ref:`doc_data_eitemorigin`: Set the item origin. For example, setting the origin to ``Admin`` will cause items to spawn at full quality. Defaults to ``Craft``.
 
 **Reward_#_Sight** *uint16*: Override for the sight attachment that should be attached to the item reward.
 
@@ -142,7 +142,7 @@ Item_Random
 
 **Reward_#_Auto_Equip** *flag*: Item should be automatically equipped by the player.
 
-**Reward_#_Origin** :ref:`doc_data_eitemorigin`: Set the item origin. For example, setting the origin to ``Admin`` will cause items to spawn at full quality. Defaults to `Craft`.
+**Reward_#_Origin** :ref:`doc_data_eitemorigin`: Set the item origin. For example, setting the origin to ``Admin`` will cause items to spawn at full quality. Defaults to ``Craft``.
 
 Hint
 ````

--- a/assets/physics-material-asset.rst
+++ b/assets/physics-material-asset.rst
@@ -7,7 +7,7 @@ Work-in-progress feature to allow custom physics effects rather than hardcoding 
 
 The ``PhysicsMaterialAsset`` type associates gameplay properties and effects with custom Unity "physic" materials. For example if none of the built-in physics materials has appropriate effects for the surface of Mars, a custom Unity physics material named "MarsDirt" could be created. Then a physics material asset with ``UnityName`` set to "MarsDirt" and ``Fallback`` of 33650ff924b34f8d9c5a0fd97418cd3e (built-in gravel) could add custom effects for the Martian surfaces.
 
-The ``PhysicsMaterialExtensionAsset`` type can be used to insert custom properties into built-in physics materials. For example if a custom laser gun should leave burn marks on the hit surface rather than bullet holes, an extension asset can set the `Base` property to a built-in physics material to add custom effects.
+The ``PhysicsMaterialExtensionAsset`` type can be used to insert custom properties into built-in physics materials. For example if a custom laser gun should leave burn marks on the hit surface rather than bullet holes, an extension asset can set the ``Base`` property to a built-in physics material to add custom effects.
 
 Properties
 ----------

--- a/assets/vehicle-asset.rst
+++ b/assets/vehicle-asset.rst
@@ -64,7 +64,7 @@ Vehicle Properties
 
 **Steering_Tire_#** *int32*: Set a ``Wheel_#`` GameObject as a steering tire, which will visibly turn when steering. By default, a number of steering tires equal to the value of ``Num_Steering_Tires`` will be automatically set. These will start at ``Steering_Tire_0 0`` (corresponding to ``Wheel_0``), and increment upwards.
 
-**Supports_Mobile_Buildables** *flag*: Certain barricades cannot be placed on vehicles by default, or if the barricade's `Allow_Placement_On_Vehicle` is set to `false`. This flag bypasses those per-barricade restrictions, allowing them to be placed on the vehicle.
+**Supports_Mobile_Buildables** *flag*: Certain barricades cannot be placed on vehicles by default, or if the barricade's ``Allow_Placement_On_Vehicle`` is set to ``false``. This flag bypasses those per-barricade restrictions, allowing them to be placed on the vehicle.
 
 **Tire_ID** *uint16*: ID of the item that should given when a tire is manually removed with a :ref:`ToolAsset <doc_item_asset_tire>` that has ``Mode Remove``, and can also be manually attached to the vehicle if the specified item ID is for a :ref:`ToolAsset <doc_item_asset_tire>` with ``Mode Add``. Defaults to 1451.
 

--- a/servers/server-hosting.rst
+++ b/servers/server-hosting.rst
@@ -144,7 +144,7 @@ How to Launch Server on Windows
 
 8. When the command-line interface stops outputting new lines of text, it has finished loading (and finished generating all necessary files). You can safely close the server by executing (typing, and then pressing the "↵ Enter" key on your keyboard) the following command on the command-line interface: ``shutdown``
 
-9. The batch script has created a new file directory located in ``...\U3DS\Servers``, called "MyServer". This directory is where all the savedata and configuration files are kept. Changing the `MyServer` ServerID (from step 5) in the batch script to a different name will allow for keeping savedata separate across multiple servers, and for running multiple servers at once.
+9. The batch script has created a new file directory located in ``...\U3DS\Servers``, called "MyServer". This directory is where all the savedata and configuration files are kept. Changing the ``MyServer`` ServerID (from step 5) in the batch script to a different name will allow for keeping savedata separate across multiple servers, and for running multiple servers at once.
 
 10. (optional) For your server to be visible on the in-game Internet server list you will need to set a :ref:`Login Token <doc_servers_gslt>` and configure :ref:`Fake IP <doc_servers_fake_ip>` or :ref:`Port Forwarding <doc_servers_port_forward>`.
 


### PR DESCRIPTION
Some text intended to be `codeblocked` was instead *italicized* (due to RST needing 2 backticks `` backticks for codeblocks). This PR should fix all of them.