### PR TITLE
Data tables for Backpack, Hat, & Vest classes

### DIFF
--- a/assets/item-asset/backpack-asset.rst
+++ b/assets/item-asset/backpack-asset.rst
@@ -3,22 +3,40 @@
 Backpack Assets
 ===============
 
-Backpacks can be worn by players and zombies.
+The ItemBackpackAsset class is used by clothing items occupying the "backpack" slot. Backpacks can be worn by players and zombies.
 
-This inherits the :ref:`BagAsset <doc_item_asset_bag>` class.
+Game Data File
+--------------
 
-Item Asset Properties
----------------------
+The ItemBackpackAsset class inherits properties from the :ref:`ItemBagAsset <doc_item_asset_bag>` class. Properties that are required (or recommended) are listed in the table below.
 
-**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+.. list-table::
+   :widths: 30 40 30
+   :header-rows: 1
+   
+   * - Class
+     - Property Name
+     - Required Value
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`GUID <doc_item_asset_intro:guid>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`ID <doc_item_asset_intro:id>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`Type <doc_item_asset_intro:type>`
+     - ``Backpack``
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`Useable <doc_item_asset_intro:useable>`
+     - ``Clothing``
 
-**Type** *enum* (``Backpack``)
+Some inherited properties behave differently when used by this class. Notably, these are:
 
-**Useable** *enum* (``Clothing``)
+#. | :ref:`Armor <doc_item_asset_clothing:armor>` (from :ref:`ItemClothingAsset <doc_item_asset_clothing>`). Backpacks do not cover any body part(s) when worn, so this property has no effect.
 
-**ID** *uint16*: Must be a unique identifier.
+#. | :ref:`InventoryAudio <doc_item_asset_intro:inventoryaudio>` (from :ref:`ItemAsset <doc_item_asset_intro>`). Defaults to ``Sounds/Inventory/LightMetalEquipment.asset`` when :ref:`Width <doc_item_asset_bag:width>` or :ref:`Height <doc_item_asset_bag:height>` are less than ``3``. To ``Sounds/Inventory/MediumMetalEquipment.asset`` when less than ``6``. Otherwise, to ``Sounds/Inventory/HeavyMetalEquipment.asset``.
 
-Backpack Asset Properties
--------------------------
+Properties
+``````````
 
-Backpacks have no unique asset properties. Refer to parent classes for additional properties.
+Backpacks have no unique properties. Refer to parent classes for additional properties instead.

--- a/assets/item-asset/hat-asset.rst
+++ b/assets/item-asset/hat-asset.rst
@@ -3,22 +3,34 @@
 Hat Assets
 ==========
 
-Hats can be worn by players and zombies.
+The ItemHatAsset class is used by clothing items occupying the "hat" slot. Hats can be worn by players and zombies, and cover their head.
 
-This inherits the :ref:`GearAsset <doc_item_asset_gear>` class.
+Game Data File
+--------------
 
-Item Asset Properties
----------------------
+The ItemHatAsset class inherits properties from the :ref:`ItemGearAsset <doc_item_asset_gear>` class. Properties that are required (or recommended) are listed in the table below.
 
-**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+.. list-table::
+   :widths: 30 40 30
+   :header-rows: 1
+   
+   * - Class
+     - Property Name
+     - Required Value
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`GUID <doc_item_asset_intro:guid>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`ID <doc_item_asset_intro:id>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`Type <doc_item_asset_intro:type>`
+     - ``Hat``
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`Useable <doc_item_asset_intro:useable>`
+     - ``Clothing``
 
-**Type** *enum* (``Hat``)
+Properties
+``````````
 
-**Useable** *enum* (``Clothing``)
-
-**ID** *uint16*: Must be a unique identifier.
-
-Hat Asset Properties
---------------------
-
-Hats have no unique asset properties. Refer to parent classes for additional properties.
+Hats have no unique properties. Refer to parent classes for additional properties instead.

--- a/assets/item-asset/vest-asset.rst
+++ b/assets/item-asset/vest-asset.rst
@@ -3,22 +3,34 @@
 Vest Assets
 ===========
 
-Vests can be worn by players and zombies.
+The ItemVestAsset class is used by clothing items occupying the "vest" slot. Vests can be worn by players and zombies, and cover their torso.
 
-This inherits the :ref:`BagAsset <doc_item_asset_bag>` class.
+Game Data File
+--------------
 
-Item Asset Properties
----------------------
+The ItemVestAsset class inherits properties from the :ref:`ItemBagAsset <doc_item_asset_bag>` class. Properties that are required (or recommended) are listed in the table below.
 
-**GUID** *32-digit hexadecimal*: Refer to :ref:`GUID <doc_data_guid>` documentation.
+.. list-table::
+   :widths: 30 40 30
+   :header-rows: 1
+   
+   * - Class
+     - Property Name
+     - Required Value
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`GUID <doc_item_asset_intro:guid>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`ID <doc_item_asset_intro:id>`
+     - 
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`Type <doc_item_asset_intro:type>`
+     - ``Vest``
+   * - :ref:`ItemAsset <doc_item_asset_intro>`
+     - :ref:`Useable <doc_item_asset_intro:useable>`
+     - ``Clothing``
 
-**Type** *enum* (``Vest``)
+Properties
+``````````
 
-**Useable** *enum* (``Clothing``)
-
-**ID** *uint16*: Must be a unique identifier.
-
-Vest Asset Properties
----------------------
-
-Vests have no unique asset properties. Refer to parent classes for additional properties.
+Vests have no unique properties. Refer to parent classes for additional properties instead.


### PR DESCRIPTION
The docs for **ItemBackpackAsset**, **ItemHatAsset**, and **ItemVestAsset** are updated to use the 'data tables' format.

The backpack doc now includes information about _InventoryAudio_ defaults.