### PR TITLE
Styleguide clean-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Most documentation files are formatted similarly. Some important notes:
 
 - The `code-block` directive can be used to display example code with syntax highlighting. Common languages include `cs`, `json`, `text`, `shell`, `bat`, and `unturneddat` (alias: `unturnedasset`).
 
-- Including links to our Unturned Wiki can be helpful. These should use the `https://unturned.wiki/` shortlink instead of `https://unturned.wiki.gg/`. Wiki articles linked to from the Unturned Documentation should have the "[Category:Pages linked from Unturned Documentation](https://unturned.wiki.gg/wiki/Category:Pages_linked_from_Unturned_Documentation)" hidden tracking category added to them.
+- Including links to our Unturned Wiki can be helpful. These should use the `https://unturned.wiki/` shortlink instead of `https://unturned.wiki.gg/`. Wiki articles linked to from the Unturned Documentation should have the "[Category:Pages linked from Unturned Documentation](https://unturned.wiki/wiki/Category:Pages_linked_from_Unturned_Documentation)" hidden tracking category added to them.
 
 Building the Docs
 -----------------

--- a/README.md
+++ b/README.md
@@ -27,13 +27,17 @@ The online documentation pages are generated from .rst (reStructuredText) files.
 
 Most documentation files are formatted similarly. Some important notes:
 
-- When asset properties are listed, they should generally follow a `**Name** *data type*: Description` format. Depending on the data type, it may be hyperlinked instead of italicized, or may also include required values if there is one.
-
 - Content block directives can be used to add notes, warnings, tips, and other admonitions.
 
-- Internal links should use the `:ref:` command.
+- Internal links should use the `:ref:` command, usually pointing towards a custom anchor.
+
+- Properties in the asset manual pages use one of two formats. Older pages follow a `**Name** *data type*: Description` format. Depending on the data type, it may be hyperlinked instead, or may include required (or possible) values. Newer pages follow a table-based format. These formats should not be mixed on the same page, but continuing to use the legacy format on pages that have not been converted yet is acceptable.
 
 - Images from the Unity editor should crop out any unnecessary information. This usually includes the Title Bar (which includes details such as the Unity version, project name, and window buttons), and the Toolbar.
+
+- The `code-block` directive can be used to display example code with syntax highlighting. Common languages include `cs`, `json`, `text`, `shell`, `bat`, and `unturneddat` (alias: `unturnedasset`).
+
+- Including links to our Unturned Wiki can be helpful. These should use the `https://unturned.wiki/` shortlink instead of `https://unturned.wiki.gg/`. Wiki articles linked to from the Unturned Documentation should have the "[Category:Pages linked from Unturned Documentation](https://unturned.wiki.gg/wiki/Category:Pages_linked_from_Unturned_Documentation)" hidden tracking category added to them.
 
 Building the Docs
 -----------------

--- a/_extensions/unturned_lexer.py
+++ b/_extensions/unturned_lexer.py
@@ -12,7 +12,7 @@ from pygments.token import *
 
 class UnturnedLexer(RegexLexer):
     name = 'UnturnedDat'
-    aliases = ['unturned']
+    aliases = ['unturneddat', 'unturnedasset']
     filenames = ['*.asset', '*.dat']
 
     tokens = {
@@ -33,4 +33,5 @@ class UnturnedLexer(RegexLexer):
     }
 
 def setup(sphinx):
-    sphinx.add_lexer("unturned", UnturnedLexer)
+    sphinx.add_lexer("unturneddat", UnturnedLexer)
+    sphinx.add_lexer("unturnedasset", UnturnedLexer)

--- a/assets/asset-bundles.rst
+++ b/assets/asset-bundles.rst
@@ -34,7 +34,7 @@ Master bundles can be loaded from any directory the game loads \*.dat files from
 
 MasterBundle.dat can set the following keys:
 
-.. code-block:: cs
+.. code-block:: unturneddat
 	
 	// Name of asset bundle file in the same directory as MasterBundle.dat.
 	Asset_Bundle_Name core.masterbundle
@@ -48,7 +48,7 @@ MasterBundle.dat can set the following keys:
 
 Individual asset \*.dats can set the following keys:
 
-.. code-block:: cs
+.. code-block:: unturneddat
 	
 	// Name of master bundle to load files from.
 	Master_Bundle_Override core.masterbundle

--- a/assets/crafting-blacklist-asset.rst
+++ b/assets/crafting-blacklist-asset.rst
@@ -9,7 +9,7 @@ Prevents specific items or blueprints from being used while crafting. They are h
 
 **Input_Items** array of Item :ref:`Asset Pointers <doc_data_assetptr>`: Any blueprints consuming these items cannot be crafted. For example (blacklisted items are highlighted):
 
-.. code-block:: unturned
+.. code-block:: unturnedasset
 	:linenos:
 	:emphasize-lines: 4, 7-10, 13-16
 
@@ -35,7 +35,7 @@ Prevents specific items or blueprints from being used while crafting. They are h
 
 **Blueprints** array: Prevent specific individual blueprints from being crafted. Each entry has an ``Item`` :ref:`Asset Pointer <doc_data_assetptr>` and ``Blueprint`` index. For example, to prevent the Chef Hat from being salvaged:
 
-.. code-block:: unturned
+.. code-block:: unturnedasset
 
 	Blueprints
 	[

--- a/assets/currency-asset.rst
+++ b/assets/currency-asset.rst
@@ -22,7 +22,7 @@ The currency asset defines how numbers are formatted, which items make up the cu
 
 **Entries**: Array of items in the currency. Each has an **Item** GUID and **Value** integer. Optionally **Is_Visible_In_Vendor_Menu** bool can be false to hide the item from the NPC vendor currency list. For example these are the $10 and $20 notes in the Canadian currency:
 
-.. code-block:: cs
+.. code-block:: unturnedasset
 	
 	{
 		"Item"
@@ -51,6 +51,6 @@ Testing
 
 The built-in "give" command accepts currency GUIDs as an alternative to item IDs. For example the following grants $1,000 CAD to the local player:
 
-.. code-block:: bash
+.. code-block:: shell
 	
 	/give 5150ca8f765d4a68bfe54912146da410/1000

--- a/assets/item-asset/arrest-end-asset.rst
+++ b/assets/item-asset/arrest-end-asset.rst
@@ -3,7 +3,7 @@
 Arrest End Assets
 =================
 
-The ItemArrestEndAsset class is used for "releaser" items, which can remove a corresponding ":ref:`catcher <doc_item_asset_arrest_start>`" item that is restraining a player. An example of a vanilla releaser is the `Handcuffs Key <https://unturned.wiki.gg/wiki/Handcuffs_Key>`_.
+The ItemArrestEndAsset class is used for "releaser" items, which can remove a corresponding ":ref:`catcher <doc_item_asset_arrest_start>`" item that is restraining a player. An example of a vanilla releaser is the `Handcuffs Key <https://unturned.wiki/wiki/Handcuffs_Key>`_.
 
 Game Data File
 --------------

--- a/assets/item-asset/arrest-start-asset.rst
+++ b/assets/item-asset/arrest-start-asset.rst
@@ -3,7 +3,7 @@
 Arrest Start Assets
 ===================
 
-The ItemArrestStartAsset class is used for "catcher" items, which can restrain a player. Its sister item, the ":ref:`releaser <doc_item_asset_arrest_start>`", can be used to unlock restraints. Some examples of vanilla catchers include the `Handcuffs <https://unturned.wiki.gg/wiki/Handcuffs>`_ and `Cable Tie <https://unturned.wiki.gg/wiki/Cable_Tie>`_.
+The ItemArrestStartAsset class is used for "catcher" items, which can restrain a player. Its sister item, the ":ref:`releaser <doc_item_asset_arrest_start>`", can be used to unlock restraints. Some examples of vanilla catchers include the `Handcuffs <https://unturned.wiki/wiki/Handcuffs>`_ and `Cable Tie <https://unturned.wiki/wiki/Cable_Tie>`_.
 
 Game Data File
 --------------

--- a/assets/item-asset/barricade-asset.rst
+++ b/assets/item-asset/barricade-asset.rst
@@ -31,7 +31,7 @@ Barricade Asset Properties
 
 **Allow_Placement_On_Vehicle** *bool*: If true, this barricade can be placed on vehicles. Defaults to true, except when using ``Build Bed``, ``Build Sentry``, or ``Build Sentry_Freeform``.
 
-**Armor_Tier** *enum* (``Low``, ``High``): Barricade armor can either be low-tier or high-tier. Defaults to low-tier, except when the barricade's name contains the word "Metal". By default, barricades with low-tier armor take 100% of the damage they receive, while barricades with high-tier armor take 50% of the damage they receive. These multipliers can be configured in the `gameplay config <https://unturned.wiki.gg/wiki/Gameplay_config>`_.
+**Armor_Tier** *enum* (``Low``, ``High``): Barricade armor can either be low-tier or high-tier. Defaults to low-tier, except when the barricade's name contains the word "Metal". By default, barricades with low-tier armor take 100% of the damage they receive, while barricades with high-tier armor take 50% of the damage they receive. These multipliers can be configured in the `gameplay config <https://unturned.wiki/wiki/Gameplay_config>`_.
 
 **Bypass_Claim** *flag*: Can be placed inside someone else's claimed area.
 
@@ -63,11 +63,11 @@ Barricade Asset Properties
 
 **Salvage_Duration_Multiplier** *float*: Multiplier on how long it takes to salvage this barricade. Setting this to a larger number will cause salvaging to take longer. Defaults to 1.
 
-**Unpickupable** *flag*: Disables the ability to pick up a placed barricade. For example, the `Horde Beacon <https://unturned.wiki.gg/wiki/Horde_Beacon>`_ uses this flag.
+**Unpickupable** *flag*: Disables the ability to pick up a placed barricade. For example, the `Horde Beacon <https://unturned.wiki/wiki/Horde_Beacon>`_ uses this flag.
 
-**Unrepairable** *flag*: Cannot be repaired by a :ref:`MeleeAsset <doc_item_asset_melee>` with the ``Repair`` flag. For example, the `Blowtorch <https://unturned.wiki.gg/wiki/Blowtorch>`_ would not be able to repair this barricade.
+**Unrepairable** *flag*: Cannot be repaired by a :ref:`MeleeAsset <doc_item_asset_melee>` with the ``Repair`` flag. For example, the `Blowtorch <https://unturned.wiki/wiki/Blowtorch>`_ would not be able to repair this barricade.
 
-**Unsalvageable** *flag*: Salvaging a damaged barricade yields no partial resources. For example, `small glass plates <https://unturned.wiki.gg/wiki/Small_Glass_Plate>`_ use this flag.
+**Unsalvageable** *flag*: Salvaging a damaged barricade yields no partial resources. For example, `small glass plates <https://unturned.wiki/wiki/Small_Glass_Plate>`_ use this flag.
 
 **Unsaveable** *flag*: This barricade is excluded from being saved. For example, carepackages use this flag.
 

--- a/assets/item-asset/clothing-asset.rst
+++ b/assets/item-asset/clothing-asset.rst
@@ -197,7 +197,7 @@ When this flag is included, this clothing item is considered waterproof. When wa
 Skin_Override :ref:`string <doc_data_builtin_types>`
 ::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-Optional name of a renderer that should use the player's skin material. For example, the `Conflicting Conscience <https://unturned.wiki.gg/wiki/Conflicting_Conscience>`_ cosmetic adds miniature versions of the player sitting on their shoulder. 
+Optional name of a renderer that should use the player's skin material. For example, the `Conflicting Conscience <https://unturned.wiki/wiki/Conflicting_Conscience>`_ cosmetic adds miniature versions of the player sitting on their shoulder. 
 
 ----
 

--- a/assets/item-asset/farm-asset.rst
+++ b/assets/item-asset/farm-asset.rst
@@ -23,7 +23,7 @@ Item Asset Properties
 Farm Asset Properties
 ---------------------
 
-**Affected_By_Agriculture_Skill** *bool*: If true, the amount of crops acquired when harvesting the plant is affected by the `Agriculture skill <https://unturned.wiki.gg/wiki/Skills>`_. Defaults to true.
+**Affected_By_Agriculture_Skill** *bool*: If true, the amount of crops acquired when harvesting the plant is affected by the `Agriculture skill <https://unturned.wiki/wiki/Skills>`_. Defaults to true.
 
 **Allow_Fertilizer** *bool*: If true, allows the player to use fertilizer to fully grow the plant. Defaults to true.
 

--- a/assets/item-asset/gun-asset.rst
+++ b/assets/item-asset/gun-asset.rst
@@ -3,7 +3,7 @@
 Gun Assets
 ==========
 
-The ItemGunAsset class is used for ranged weapons (or "guns"), which can be used by players to deal damage. Some examples of vanilla ranged weapons include the `Eaglefire <https://unturned.wiki.gg/wiki/Eaglefire>`_ and `Crossbow <https://unturned.wiki.gg/wiki/Crossbow>`_.
+The ItemGunAsset class is used for ranged weapons (or "guns"), which can be used by players to deal damage. Some examples of vanilla ranged weapons include the `Eaglefire <https://unturned.wiki/wiki/Eaglefire>`_ and `Crossbow <https://unturned.wiki/wiki/Crossbow>`_.
 
 Unity Asset Bundle Contents
 ---------------------------
@@ -507,7 +507,7 @@ Action :ref:`EAction <doc_item_asset_gun:eaction>`
 
 The value of this property determines how the weapon functions when used, including whether it uses *ballistic projectiles*, or *physics projectiles*. Different properties are available to the weapon depending on the value of this property.
 
-Although most action mechanisms utilize ballistic projectiles, the ``Rocket`` action mechanism uses physics projectiles instead. Additionally, any projectiles from these weapons (e.g., the `Rocket Launcher <https://unturned.wiki.gg/wiki/Rocket_Launcher>`_) are explosive.
+Although most action mechanisms utilize ballistic projectiles, the ``Rocket`` action mechanism uses physics projectiles instead. Additionally, any projectiles from these weapons (e.g., the `Rocket Launcher <https://unturned.wiki/wiki/Rocket_Launcher>`_) are explosive.
 
 To fire a weapon with the  ``String`` action mechanism, a player must be aiming down sights – unless a "Nock" GameObject has been added during its Unity setup.
 

--- a/assets/item-asset/gun-asset.rst
+++ b/assets/item-asset/gun-asset.rst
@@ -596,7 +596,7 @@ When this property is unset, it will default to ``0``. When the ``Attachment_Cal
 
 For example, a valid configuration for a ranged weapon's calibers could be:
 
-.. code-block:: unturned
+.. code-block:: unturnedasset
 
   Attachment_Calibers 2
   Attachment_Caliber_0 1

--- a/assets/item-asset/structure-asset.rst
+++ b/assets/item-asset/structure-asset.rst
@@ -25,7 +25,7 @@ Item Asset Properties
 Structure Asset Properties
 --------------------------
 
-**Armor_Tier** *enum* (``Low``, ``High``): Armor is a multiplier on damage received. A structure's armor tier can either be low-tier or high-tier. By default, structures with low-tier armor take 100% of the damage they receive, while structures with high-tier armor take 50% of the damage they receive. These multipliers can be configured in the `gameplay config <https://unturned.wiki.gg/wiki/Gameplay_config>`_. Defaults to low-tier, except when the structure's name contains the word "Metal" or "Brick".
+**Armor_Tier** *enum* (``Low``, ``High``): Armor is a multiplier on damage received. A structure's armor tier can either be low-tier or high-tier. By default, structures with low-tier armor take 100% of the damage they receive, while structures with high-tier armor take 50% of the damage they receive. These multipliers can be configured in the `gameplay config <https://unturned.wiki/wiki/Gameplay_config>`_. Defaults to low-tier, except when the structure's name contains the word "Metal" or "Brick".
 
 **Can_Be_Damaged** *bool*: If true, this structure can be damaged. Defaults to true.
 
@@ -53,7 +53,7 @@ Structure Asset Properties
 
 **Unpickupable** *flag*: Disables the ability to pick up a placed structure.
 
-**Unrepairable** *flag*: Cannot be repaired by a :ref:`MeleeAsset <doc_item_asset_melee>` with the ``Repair`` flag. For example, the `Blowtorch <https://unturned.wiki.gg/wiki/Blowtorch>`_ would not be able to repair this structure.
+**Unrepairable** *flag*: Cannot be repaired by a :ref:`MeleeAsset <doc_item_asset_melee>` with the ``Repair`` flag. For example, the `Blowtorch <https://unturned.wiki/wiki/Blowtorch>`_ would not be able to repair this structure.
 
 **Unsalvageable** *flag*: Salvaging a damaged structure yields no partial resources.
 

--- a/assets/item-asset/trap-asset.rst
+++ b/assets/item-asset/trap-asset.rst
@@ -27,7 +27,7 @@ Trap Asset Properties
 
 **Barricade_Damage** *float*: Damage dealt to barricades caught within the area-of-effect explosion.
 
-**Broken** *flag*: Players who trigger the trap will be inflicted with the `Broken Bones <https://unturned.wiki.gg/wiki/Broken_Bones>`_ status effect.
+**Broken** *flag*: Players who trigger the trap will be inflicted with the `Broken Bones <https://unturned.wiki/wiki/Broken_Bones>`_ status effect.
 
 **Damage_Tires** *flag*: This trap can pop the tires of vehicles that drive over it.
 

--- a/assets/material-palette-asset.rst
+++ b/assets/material-palette-asset.rst
@@ -17,7 +17,7 @@ Material Palette Properties
 
 **Materials** *array* of :ref:`Master Bundle Pointer <doc_data_masterbundleptr>` *dictionaries*: Each dictionary in the list should point to a material bundled in Unity.
 
-.. code-block:: cs
+.. code-block:: unturnedasset
 	
 	"Asset"
 	{

--- a/assets/npc-asset/conditions.rst
+++ b/assets/npc-asset/conditions.rst
@@ -262,7 +262,7 @@ Time_Of_Day
 
 **Condition_#_Type** *enum* (``Time_Of_Day``)
 
-**Condition_#_Second** *int*: Second of a 24-hour clock (military time) to compare against. For example: ``0`` is midnight (the start of a day), ``43200`` is noon (12 o'clock), and ``86400`` is midnight (the end of a day). This condition respects the map's configured "Bias" values, as well as the day/night cycle length of the world. As a visual reference, the `Clock <https://unturned.wiki.gg/wiki/Clock>`_ item can be used.
+**Condition_#_Second** *int*: Second of a 24-hour clock (military time) to compare against. For example: ``0`` is midnight (the start of a day), ``43200`` is noon (12 o'clock), and ``86400`` is midnight (the end of a day). This condition respects the map's configured "Bias" values, as well as the day/night cycle length of the world. As a visual reference, the `Clock <https://unturned.wiki/wiki/Clock>`_ item can be used.
 
 Weather_Blend_Alpha
 ```````````````````

--- a/assets/outfit-asset.rst
+++ b/assets/outfit-asset.rst
@@ -17,7 +17,7 @@ Outfit Properties
 
 **Items** *array* of :ref:`Asset Pointers <doc_data_assetptr>`: Asset pointers to clothing item(s). These clothing items will be worn together in any preview images generated of this outfit. For example:
 
-.. code-block:: cs
+.. code-block:: unturnedasset
 	
 	"Asset"
 	{

--- a/assets/stereo-song-asset.rst
+++ b/assets/stereo-song-asset.rst
@@ -12,7 +12,7 @@ Asset Properties Reference
 
 **Title** string: display text to show in the music player menu. If a localization .dat file is present the ``Name`` key will be used, or a translation reference can be used. Examples:
 
-.. code-block:: cs
+.. code-block:: unturnedasset
 	
 	"Title" "My song"
 
@@ -22,7 +22,7 @@ OR
 
 OR
 
-.. code-block:: cs
+.. code-block:: unturnedasset
 	
 	"Title"
 	{
@@ -32,7 +32,7 @@ OR
 
 **Song** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: audio clip to play. Can either be a newer master bundle pointer or an older content pointer. Examples:
 
-.. code-block:: cs
+.. code-block:: unturnedasset
 	
 	"Song"
 	{
@@ -42,7 +42,7 @@ OR
 
 OR
 
-.. code-block:: cs
+.. code-block:: unturnedasset
 	
 	"Song"
 	{

--- a/assets/vehicle-physics-profile-asset.rst
+++ b/assets/vehicle-physics-profile-asset.rst
@@ -12,7 +12,7 @@ How to test?
 
 In 3.19.18.0 the **reload** command was introduced which can be used to reload specific assets or directories of assets while playing. Simply reload the physics profile and then respawn a vehicle. For example to reload the default profile:
 
-.. code-block:: bash
+.. code-block:: shell
 
 	/reload 6b91a94f01b6472eaca31d9420ec2367
 

--- a/assets/weather-asset.rst
+++ b/assets/weather-asset.rst
@@ -12,7 +12,7 @@ How to test?
 
 When a GUID is passed to the weather command it will start a custom weather event, and 0 can be used to end it.
 
-.. code-block:: bash
+.. code-block:: shell
 	
 	/weather 819982d7a2b6453488a8c4c5d9efe67f
 

--- a/data/asset-ptr.rst
+++ b/data/asset-ptr.rst
@@ -10,7 +10,7 @@ In \*.dat files
 
 Note that the GUID here is not wrapped in quotes because Unturned \*.dat files are treated as pairs of strings.
 
-.. code-block::
+.. code-block:: unturneddat
 	
 	MyAssetPtr ################################
 
@@ -19,7 +19,7 @@ In \*.asset files
 
 Two formats are supported in these files. The inline style was added later so you will see the older style used in many official assets.
 
-.. code-block:: cs
+.. code-block:: unturnedasset
 	
 	"MyAssetPtr" "################################"
 	"MyAssetPtr" { "GUID" "################################" }

--- a/data/master-bundle-ptr.rst
+++ b/data/master-bundle-ptr.rst
@@ -12,7 +12,7 @@ In \*.asset files
 
 ``AssetPath``: File path of the Unity asset (e.g., \*.prefab, \*.mat, \*.png, or \*.ogg files). This path is relative to the ``Asset_Prefix`` path configured in the ``MasterBundle.dat`` file.
 
-.. code-block:: cs
+.. code-block:: unturnedasset
 	
 	"MyMasterBundlePtr"
 	{
@@ -22,12 +22,12 @@ In \*.asset files
 
 If the asset default master bundle should be used, then the path can be specified inline:
 
-.. code-block:: cs
+.. code-block:: unturnedasset
 	
 	"MyMasterBundlePtr" "path/to/file.extension"
 
 Alternatively, the name of a master bundle can be prefixed to the inline path:
 
-.. code-block:: cs
+.. code-block:: unturnedasset
 	
 	"MyMasterBundlePtr" "core.masterbundle:path/to/file.extension"

--- a/mapping/level-batching.rst
+++ b/mapping/level-batching.rst
@@ -45,7 +45,7 @@ Excluding specific objects and resources from batching
 
 If you know your asset is incompatible you can add this line to the .dat file:
 
-.. code-block:: cs
+.. code-block:: unturneddat
 
 	Exclude_From_Level_Batching true
 

--- a/mapping/manual-object-culling.rst
+++ b/mapping/manual-object-culling.rst
@@ -16,7 +16,7 @@ This comes with an obvious downside: when zooming in on most buildings it is rea
 Editing volumes
 ---------------
 
-You can enable the **Preview Culling** checkbox to hide all objects inside culling volumes. This is useful to find any objects that are not included when they should be. For example, while working on this update I realized the volumes in the vanilla cargo ships did not extend low enough to catch some of the furniture in the crew quarters. 
+You can enable the **Preview Culling** checkbox to hide all objects inside culling volumes. This is useful to find any objects that are not included when they should be. For example, while working on this update I realized the volumes in the vanilla cargo ships did not extend low enough to catch some of the furniture in the crew quarters.
 
 Objects inside volumes are found when loading the level. While working in the editor you can click **Refresh Objects** to re-find all objects/volumes on the map.
 
@@ -27,7 +27,7 @@ Excluding specific objects
 
 If you know your asset should never be managed by culling volumes you can add this line to the .dat file:
 
-.. code-block:: c#
+.. code-block:: unturneddat
 	
 	Exclude_From_Culling_Volumes true
 

--- a/servers/server-auto-restart.rst
+++ b/servers/server-auto-restart.rst
@@ -77,7 +77,7 @@ This example script assumes the symbolic link exists at ``~/U3DS``.
 
 1. Save script as ``MyServer.sh`` in your home directory (e.g., ``nano ~/MyServer.sh``):
 
-.. code-block:: sh
+.. code-block:: shell
 	:linenos:
 
 	#! /usr/bin/bash

--- a/servers/server-hosting.rst
+++ b/servers/server-hosting.rst
@@ -59,13 +59,13 @@ How to Install Server using SteamCMD
 
 1. Login to Steam anonymously.
 
-.. code-block:: bash
+.. code-block:: shell
 
 	login anonymous
 
-2. Download the Unturned Dedicated Server application.
+1. Download the Unturned Dedicated Server application.
 
-.. code-block:: bash
+.. code-block:: shell
 
 	app_update 1110390
 	
@@ -73,7 +73,7 @@ How to Install Server using SteamCMD
 
 3. Close SteamCMD.
 	
-.. code-block:: bash
+.. code-block:: shell
 
 	quit
 
@@ -186,7 +186,7 @@ Common useful commands are:
 
 Examples:
 
-.. code-block:: c#
+.. code-block:: unturneddat
 
 	Map PEI
 	Map Washington
@@ -196,7 +196,7 @@ Examples:
 
 Examples:
 
-.. code-block:: c#
+.. code-block:: unturneddat
 
 		Port 27015
 		Port 27017
@@ -214,14 +214,14 @@ To include a Workshop file on your server:
 1. Browse to its web page, for example: `Hawaii <https://steamcommunity.com/sharedfiles/filedetails/?id=1753134636>`_
 2. Copy the file ID from the end of the URL.
 
-.. code-block:: c#
+.. code-block:: text
 
 	URL: https://steamcommunity.com/sharedfiles/filedetails/?id=1753134636
 	ID: 1753134636
 
 3. Insert the file ID into the File_IDs list:
 
-.. code-block:: c#
+.. code-block:: json
 
 	"File_IDs":
 	[
@@ -230,7 +230,7 @@ To include a Workshop file on your server:
 
 Multiple file IDs should be separated by commas:
 
-.. code-block:: c#
+.. code-block:: json
 
 	"File_IDs":
 	[


### PR DESCRIPTION
* [README](https://github.com/SmartlyDressedGames/Unturned-Docs/blob/bc516060adcd0a4e5b62cd778c050208640253c7/README.md) is updated with more styleguide information.
* Replaced all wiki links with our `https://unturned.wiki/` shortlink. (Mentioned in styleguide!)
* Tweaked the UnturnedLexer name in Sphinx to accept `unturneddat` and `unturnedasset` instead of `unturned`.
* Updated the language used by most code-blocks. Many of them now use unturneddat, some of them just had the language alias they were using changed to be more consistent. (Common languages are mentioned in styleguide!)