### PR TITLE
Formatting & wording tweaks for Vehicle Update changes

### DIFF
--- a/assets/item-asset/introduction.rst
+++ b/assets/item-asset/introduction.rst
@@ -194,11 +194,11 @@ EEquipableModelParent Enumeration
    * - Named Value
      - Description
    * - ``RightHook``
-     - Does not correspond to any useable type.
+     - Item is attached to Right_Hook.
    * - ``LeftHook``
-     - Corresponds to the "Clothing" useable type.
+     - Item is attached to Left_Hook.
    * - ``Spine``
-     - Corresponds to the "Gun" useable type.
+     - Item is attached to Spine.
 
 .. _doc_item_asset_intro:euseabletype:
 

--- a/assets/item-asset/introduction.rst
+++ b/assets/item-asset/introduction.rst
@@ -9,7 +9,7 @@ Unity Asset Bundle Contents
 ---------------------------
 
 .. figure:: /assets/img/UnityExampleItem.png
-	
+
 	An example of an item being set up in the Unity editor.
 
 To get started, create a new folder for your custom item. The name of this folder will be relevant when further configuring your item after it has been exported from Unity.
@@ -67,12 +67,15 @@ Properties
    * - :ref:`Amount <doc_item_asset_intro:amount>`
      - :ref:`uint8 <doc_data_builtin_types>`
      - ``1``
+   * - :ref:`Backward <doc_item_asset_intro:equipablemodelparent>`
+     - :ref:`flag <doc_data_flag>`
+     - *deprecated*
    * - :ref:`Bypass_Hash_Verification <doc_item_asset_intro:bypass_hash_verification>`
      - :ref:`bool <doc_data_builtin_types>`
      - ``false``
    * - :ref:`Bypass_ID_Limit <doc_item_asset_intro:bypass_id_limit>`
      - :ref:`flag <doc_data_flag>`
-     - 
+     -
    * - :ref:`Can_Player_Equip <doc_item_asset_intro:can_player_equip>`
      - :ref:`bool <doc_data_builtin_types>`
      - See description
@@ -92,7 +95,7 @@ Properties
      - :ref:`float32 <doc_data_builtin_types>`
      - ``1``
    * - :ref:`EquipableModelParent <doc_item_asset_intro:equipablemodelparent>`
-     - :ref:`enum <doc_data_builtin_types>`
+     - :ref:`EEquipableModelParent <doc_item_asset_intro:eequipablemodelparent>`
      - See description
    * - :ref:`EquipablePrefab <doc_item_asset_intro:equipableprefab>`
      - :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`
@@ -102,16 +105,16 @@ Properties
      - ``Equip``
    * - :ref:`GUID <doc_item_asset_intro:guid>`
      - :ref:`doc_data_guid`
-     - 
+     -
    * - :ref:`ID <doc_item_asset_intro:id>`
      - :ref:`uint16 <doc_data_builtin_types>`
      - ``0``
    * - :ref:`Ignore_TexRW <doc_item_asset_intro:ignore_texrw>`
      - :ref:`flag <doc_data_flag>`
-     - 
+     -
    * - :ref:`InspectAudioDef <doc_item_asset_intro:inspectaudiodef>`
      - :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`
-     - 
+     -
    * - :ref:`Instantiated_Item_Name_Override <doc_item_asset_intro:instantiated_item_name_override>`
      - :ref:`string <doc_data_builtin_types>`
      - See description
@@ -126,7 +129,7 @@ Properties
      - ``false``
    * - :ref:`Pro <doc_item_asset_intro:pro>`
      - :ref:`flag <doc_data_flag>`
-     - 
+     -
    * - :ref:`Procedurally_Animate_Inertia <doc_item_asset_intro:procedurally_animate_inertia>`
      - :ref:`bool <doc_data_builtin_types>`
      - ``true``
@@ -168,7 +171,7 @@ Properties
      - ``None``
    * - :ref:`Type <doc_item_asset_intro:type>`
      - :ref:`doc_data_eitemtype`
-     - 
+     -
    * - :ref:`Use_Auto_Icon_Measurements <doc_item_asset_intro:use_auto_icon_measurements>`
      - :ref:`bool <doc_data_builtin_types>`
      - ``true``
@@ -179,6 +182,24 @@ Properties
      - :ref:`EUseableType <doc_item_asset_intro:euseabletype>`
      - ``None``
 
+.. _doc_item_asset_intro:eequipablemodelparent:
+
+EEquipableModelParent Enumeration
+`````````````````````````````````
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Named Value
+     - Description
+   * - ``RightHook``
+     - Does not correspond to any useable type.
+   * - ``LeftHook``
+     - Corresponds to the "Clothing" useable type.
+   * - ``Spine``
+     - Corresponds to the "Gun" useable type.
+
 .. _doc_item_asset_intro:euseabletype:
 
 EUseableType Enumeration
@@ -187,7 +208,7 @@ EUseableType Enumeration
 .. list-table::
    :widths: 25 75
    :header-rows: 1
-   
+
    * - Named Value
      - Description
    * - ``None``
@@ -335,12 +356,12 @@ Multiplies character movement speed while equipped in the player's hands. If a g
 
 .. _doc_item_asset_intro:equipablemodelparent:
 
-EquipableModelParent ``RightHook``, ``LeftHook`` or ``Spine``
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+EquipableModelParent :ref:`EEquipableModelParent <doc_item_asset_intro:eequipablemodelparent>`
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-Overrides which transform to attach item to when equipped by the player. Spine may be a better interpolation space for items with animations moving the model between hands.
+Overrides which transform to attach the item to when equipped by the player. Spine may be a better interpolation space for items with animations moving the model between hands.
 
-The deprecated ``Backward`` flag sets ``EquipableModelParent`` to ``LeftHook``.
+Normally, this property defaults to ``RightHook``. However, items using the deprecated ``Backward`` flag will cause this to instead use ``LeftHook``.
 
 ----
 

--- a/assets/item-asset/mask-asset.rst
+++ b/assets/item-asset/mask-asset.rst
@@ -23,4 +23,4 @@ Mask Asset Properties
 
 **Earpiece** *flag*: Specified if mask allows for listening on communications by walkie-talkie.
 
-**FilterDegradationRateMultiplier** *float*: Multiplier for how quickly deadzones deplete a gasmask's filter quality. For example, 2 is faster (2x) and 0.5 is slower.
+**FilterDegradationRateMultiplier** *float32*: Multiplier for how quickly deadzones deplete a gasmask's filter quality. For example, 2 is faster (2x) and 0.5 is slower.

--- a/assets/level-asset.rst
+++ b/assets/level-asset.rst
@@ -5,7 +5,7 @@ Level Assets
 
 Each map can be associated with a **Level Asset**. These assets contain gameplay information not necessary for the main menus. Refer to :ref:`Level Config <doc_mapping_config>` for information on linking a level asset to a map.
 
-For examples check the ``Assets/Levels`` directory.
+For examples, check the ``Assets/Levels`` directory.
 
 **Type** *string*: ``SDG.Unturned.LevelAsset``
 
@@ -62,13 +62,13 @@ Skill Rule Properties
 Terrain Color Properties
 ------------------------
 
-**Color** :ref:`color <doc_data_color>`: Actual base color/albedo of terrain material.
+**Color** :ref:`color <doc_data_color>`: Actual base color/albedo of terrain material. Players will be kicked from multiplayer servers if their customized skin color is too similar to the value of this property.
 
-**HueThreshold** :ref:`float32 <doc_data_builtin_types>`: 0 to 1. If difference between hues is greater than this value the colors are not too similar.
+**HueThreshold** :ref:`float32 <doc_data_builtin_types>`: Values are clamped from 0 to 1. If difference between hues is greater than this threshold, the colors are not too similar.
 
-**SaturationThreshold** :ref:`float32 <doc_data_builtin_types>`: 0 to 1. If difference between saturations is greater than this value the colors are not too similar.
+**SaturationThreshold** :ref:`float32 <doc_data_builtin_types>`: Values are clamped from 0 to 1. If difference between saturations is greater than this threshold, the colors are not too similar.
 
-**ValueThreshold** :ref:`float32 <doc_data_builtin_types>`: 0 to 1. If difference between values is greater than this the colors are not too similar.
+**ValueThreshold** :ref:`float32 <doc_data_builtin_types>`: Values are clamped from 0 to 1. If difference between values is greater than this threshold, the colors are not too similar.
 
 Music Properties
 ----------------

--- a/assets/redirector-asset.rst
+++ b/assets/redirector-asset.rst
@@ -10,6 +10,11 @@ Redirector Assets
 Game Data File
 --------------
 
+Note that ``TargetAsset`` is required for this asset to function.
+
+Properties
+``````````
+
 .. list-table::
    :widths: 40 40 20
    :header-rows: 1
@@ -22,14 +27,19 @@ Game Data File
      - ``None``
    * - :ref:`TargetAsset <doc_asset_redirector:targetasset>`
      - :ref:`GUID <doc_data_guid>`
-     - Required
+     -
+
+Property Descriptions
+`````````````````````
 
 .. _doc_asset_redirector:assetcategory:
 
-AssetCategory :ref:`enum <doc_data_builtin_types>` ``None``
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+AssetCategory :ref:`EAssetType <doc_data_eassettype>` ``None``
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-If set, a legacy ID can be redirected as well. For example, a redirector with legacy ID of ``4`` and ``AssetCategory Item`` would be found when using ``/give 4``.
+If set, an asset's legacy ID can be redirected as well. For example: a redirector with ``AssetCategory Item`` that is pointing to an asset with the legacy ID of ``4``, would be found when using ``/give 4``.
+
+----
 
 .. _doc_asset_redirector:targetasset:
 

--- a/assets/vehicle-asset.rst
+++ b/assets/vehicle-asset.rst
@@ -38,7 +38,7 @@ Vehicle Properties
 
 **Can_Be_Locked** *bool*: Whether or not the vehicle can be locked a player. Defaults to true.
 
-**Crawler** *flag*: *deprecated* Disables the ``Wheel_#`` GameObjects from turning when steering by setting the default value of ``Num_Steering_Tires`` to 0. This property has no effect if ``Num_Steering_Tires`` has been manually set.
+**Crawler** *flag*: *This property is deprecated.* Disables the ``Wheel_#`` GameObjects from turning when steering by setting the default value of ``Num_Steering_Tires`` to 0. This property has no effect if ``Num_Steering_Tires`` has been manually set.
 
 .. note:: Replaced by the ``WheelConfigurations`` propery.
 
@@ -62,7 +62,7 @@ Vehicle Properties
 
 **LockMouse** *flag*: First-person camera movement is locked while driving. This is useful for ``Engine Plane`` and ``Engine Helicopter``, as a player's mouse movement while in first-person can be used to steer the vehicle.
 
-**Num_Steering_Tires** *int32*: *deprecated* Total number of tires that should turn when steering. Defaults to 2 when using ``Engine Car``, to 1 when using any other ``Engine`` enumerator, or to 0 if the ``Crawler`` property has been set.
+**Num_Steering_Tires** *int32*: *This property is deprecated.* Total number of tires that should turn when steering. Defaults to 2 when using ``Engine Car``, to 1 when using any other ``Engine`` enumerator, or to 0 if the ``Crawler`` property has been set.
 
 .. note:: Replaced by the ``WheelConfigurations`` propery.
 
@@ -72,7 +72,7 @@ Vehicle Properties
 
 **Should_Spawn_Seat_Capsules** *bool*: If true, capsule colliders will be attached to the ``Seat`` GameObject in order to prevent players from clipping into the ground. This is useful for vehicles that do not have a roof. Defaults to false.
 
-**Steering_Tire_#** *int32*: *deprecated* Set a ``Wheel_#`` GameObject as a steering tire, which will visibly turn when steering. By default, a number of steering tires equal to the value of ``Num_Steering_Tires`` will be automatically set. These will start at ``Steering_Tire_0 0`` (corresponding to ``Wheel_0``), and increment upwards.
+**Steering_Tire_#** *int32*: *This property is deprecated.* Set a ``Wheel_#`` GameObject as a steering tire, which will visibly turn when steering. By default, a number of steering tires equal to the value of ``Num_Steering_Tires`` will be automatically set. These will start at ``Steering_Tire_0 0`` (corresponding to ``Wheel_0``), and increment upwards.
 
 .. note:: Replaced by the ``WheelConfigurations`` propery.
 
@@ -101,6 +101,8 @@ Paint
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 If set, the vehicle can be painted with a :ref:`Vehicle Paint Tool <doc_item_asset_vehicle_paint_tool>`. Each section's material's ``_PaintColor`` property is set to the vehicle's paint color.
+
+----
 
 .. _doc_assets_vehicle:defaultpaintcolors:
 
@@ -403,7 +405,7 @@ Explosion
 **ShouldExplosionBurnMaterials** *bool*: If true, the materials of the vehicle's ``Model_#`` GameObjects will be tinted black when the vehicle is destroyed. Defaults to true if ``Explosion`` is specified.
 
 Turret
-------
+``````
 
 **Turrets** *uint8*: Number of turrets on the vehicle. All of the other turret properties require that this property is set. Defaults to 0.
 
@@ -440,11 +442,6 @@ Economy
 **Shared_Skin_Name** *string*: When generating images, the image name will contain the value of this string instead of the vehicle's file name. Often used with ``Shared_Skin_Lookup_ID``.
 
 **Size2_Z** *float*: Orthogonal camera size for economy icons.
-
-Localization
-------------
-
-**Name** *string*: Vehicle name in user interfaces.
 
 .. _doc_assets_vehicle:paintablesection_dictionary:
 
@@ -635,3 +632,9 @@ MaxVolume :ref:`float32 <doc_data_builtin_types>` ``0.0``
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 AudioSource volume when engine RPM is at :ref:`Max RPM <doc_assets_vehicle:enginemaxrpm>`.
+
+
+Localization
+------------
+
+**Name** *string*: Vehicle name in user interfaces.

--- a/assets/vehicle-redirector-asset.rst
+++ b/assets/vehicle-redirector-asset.rst
@@ -5,10 +5,17 @@ Vehicle Redirector Assets
 
 **Vehicle Redirector Assets** help consolidate legacy colored vehicle variants into a single vehicle asset.
 
-Prior to the addition of paintable vehicles, it was common to create duplicates of a vehicle asset with the color being the only difference. One of many downsides with this approach was the increased hassle of keeping changes consistent between all of the variants, for example, when tuning physics. Vehicle redirector assets ensure compatibility with existing saves and content while merging colored vehicle variants into one unified asset.
+Prior to the addition of paintable vehicles, it was common to create duplicates of a vehicle asset with the color being the only difference. One of many downsides with this approach was the increased hassle of keeping changes consistent between all of the variants; for example, when tuning physics.
+
+Vehicle redirector assets ensure compatibility with existing saves and content while merging colored vehicle variants into one unified asset.
 
 Game Data File
 --------------
+
+Note that the ``TargetVehicle`` property is required for this asset to function.
+
+Properties
+``````````
 
 .. list-table::
    :widths: 40 40 20
@@ -19,13 +26,16 @@ Game Data File
      - Default Value
    * - :ref:`TargetVehicle <doc_asset_vehicle_redirector:targetvehicle>`
      - :ref:`Asset Pointer <doc_data_assetptr>`
-     - Required
+     -
    * - :ref:`LoadPaintColor <doc_asset_vehicle_redirector:loadpaintcolor>`
      - :ref:`color <doc_data_color>`
-     - N/A
+     -
    * - :ref:`SpawnPaintColor <doc_asset_vehicle_redirector:spawnpaintcolor>`
      - :ref:`color <doc_data_color>`
-     - N/A
+     -
+
+Property Descriptions
+`````````````````````
 
 .. _doc_asset_vehicle_redirector:targetvehicle:
 
@@ -34,12 +44,16 @@ TargetVehicle :ref:`Asset Pointer <doc_data_assetptr>`
 
 Actual vehicle to use when attempting to load or spawn this asset.
 
+----
+
 .. _doc_asset_vehicle_redirector:loadpaintcolor:
 
 LoadPaintColor :ref:`color <doc_data_color>`
 ::::::::::::::::::::::::::::::::::::::::::::
 
 If set, overrides the default random paint color when loading a vehicle from a save file. Used to preserve colors of vehicles in existing saves.
+
+----
 
 .. _doc_asset_vehicle_redirector:spawnpaintcolor:
 

--- a/data/enum/eassettype.rst
+++ b/data/enum/eassettype.rst
@@ -3,7 +3,7 @@
 EAssetType
 ============
 
-The EAssetType enumerated type is used to determine an asset's type.
+The EAssetType enumerated type is used as a scope for legacy IDs. Each legacy ID is unique within an EAssetType (allowing multiple assets to share the same legacy ID when they are different types). This is only used in older code or for maintaining backwards compatibility.
 
 Enumerators
 ```````````

--- a/data/enum/eassettype.rst
+++ b/data/enum/eassettype.rst
@@ -1,0 +1,38 @@
+.. _doc_data_eassettype:
+
+EAssetType
+============
+
+The EAssetType enumerated type is used to determine an asset's type.
+
+Enumerators
+```````````
+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   * - Named Value
+     - Description
+   * - ``None``
+     - Asset type is not applicable.
+   * - ``Item``
+     - Asset is an item.
+   * - ``Effect``
+     - Asset is an effect.
+   * - ``Object``
+     - Asset is an object (this includes NPC characters).
+   * - ``Resource``
+     - Asset is a resource.
+   * - ``Vehicle``
+     - Asset is a vehicle.
+   * - ``Animal``
+     - Asset is an animal.
+   * - ``Mythic``
+     - Asset is a mythical effect.
+   * - ``Skin``
+     - Asset is a skin.
+   * - ``Spawn``
+     - Asset is a spawn table.
+   * - ``NPC``
+     - Asset is related to NPCs (such as quests, vendors, or dialogues).

--- a/data/enum/ebatterymode.rst
+++ b/data/enum/ebatterymode.rst
@@ -11,7 +11,7 @@ Enumerators
 .. list-table::
    :widths: 25 75
    :header-rows: 1
-   
+
    * - Named Value
      - Description
    * - ``None``


### PR DESCRIPTION
VehicleAsset documentation is still a lot to navigate. But I've adjusted the formatting/ordering of some stuff in it for now. Will likely reorganize more of it when adding Unity info to the page (or when converting property list to datatable format).

Added doc for EAssetType enum. Currently, only the redirector page links to it.

- [introduction to items](https://unturned--345.org.readthedocs.build/en/345/assets/item-asset/introduction.html#eequipablemodelparent-enumeration)
- [mask-asset](https://unturned--345.org.readthedocs.build/en/345/assets/item-asset/mask-asset.html#mask-asset-properties)
- [level-asset](https://unturned--345.org.readthedocs.build/en/345/assets/level-asset.html#terrain-color-properties)
- [redirector-asset](https://unturned--345.org.readthedocs.build/en/345/assets/redirector-asset.html)
- [vehicle-asset](https://unturned--345.org.readthedocs.build/en/345/assets/vehicle-asset.html#paint)
- [vehicle-redirector-asset](https://unturned--345.org.readthedocs.build/en/345/assets/vehicle-redirector-asset.html)
- [eassettype](https://unturned--345.org.readthedocs.build/en/345/data/enum/eassettype.html)