### PR TITLE
Update "Building the Docs" info

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,7 @@
 version: 2
 
 # Enabling PDF and EPUB builds, for offline use
-formats:
-  - pdf
-  - epub
+formats: all
 
 build:
   os: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The built documentation is hosted by [Read the Docs](https://readthedocs.org/) h
 Offline Downloads
 -----------------
 
-PDF and Epub versions of the documentation can be [downloaded](https://readthedocs.org/projects/unturned/downloads/) for offline use.
+PDF, ePub, and zipped HTML versions of the documentation can be [downloaded](https://readthedocs.org/projects/unturned/downloads/) for offline use.
 
 Contributing
 ------------
@@ -42,16 +42,24 @@ Most documentation files are formatted similarly. Some important notes:
 Building the Docs
 -----------------
 
-The documentation is written in [reStructuredText](https://www.writethedocs.org/guide/writing/reStructuredText/) and parsed/built using [Sphinx](https://github.com/sphinx-doc/sphinx).
+This section explains how to build a local copy of the documentation. Our documentation is written in [reStructuredText](https://www.writethedocs.org/guide/writing/reStructuredText/), and converted to HTML through [Sphinx](https://github.com/sphinx-doc/sphinx).
 
-Building requires the *Read the Docs* theme. To install it, run this command in the repository directory:
+When building locally, we recommend using [Visual Studio Code](https://code.visualstudio.com/). Install the [Esbonio extension](https://docs.esbon.io/en/latest/index.html) by Swyddfa, and the [reStructuredText extension](https://docs.restructuredtext.net/) by LeXtudio Inc. You can find the full documentation for those extensions on their websites.
 
-`py -m pip install -r requirements.txt`
+The version of Python used by the project is noted in the `.readthedocs.yaml` file. When building, you should use the same version of Python as used by the documentation. If you have multiple versions of Python installed, you may need to manually specify the version that should be used when running commands.
 
-*py runs the python interpreter. -m is short for -module and specifies the pip package installer module. -r is short for --requirement and specifies a file with a list of package names to install.*
+Before you can build the documentation, you will need to download all of its dependencies. From the repository's directory, run the following command:
 
-With Python and Sphinx installed run `make html` in the root folder to create the site locally at `/_build/html/index.html`.
+```shell
+py -m pip install -r requirements.txt
+```
 
-Editing using [Visual Studio Code](https://code.visualstudio.com/) with the [reStructuredText Extension](https://docs.restructuredtext.net/) is recommended.
+<small>*`py` runs the python interpreter, and can be used to specify the python version that should be used. `-m pip install` is used to select the pip package installer module. `-r requirements.txt` will install dependencies pinned in the specified requirements file.*</small>
 
-The project's `requirements.txt` file is automatically generated. To update this file, install `pip-tools` and run `pip-compile requirements.in`. Important dependencies (and their versions) should be pinned in `requirements.in`.
+With the project installed, run `make html` in the root folder. This will create the documentation locally at `/_build/html/index.html`. If you installed Esbonio correctly, you can preview how the documentation would look with the site's theme as well.
+
+The project's `requirements.txt` file is automatically generated. If you need to add or update dependencies, these should be pinned in `requirements.in` instead. Run the following command (available from `pip-tools`) to generate a new requirements file afterwards:
+
+```shell
+pip-compile requirements.in
+```

--- a/conf.py
+++ b/conf.py
@@ -10,7 +10,7 @@ project = "Unturned"
 copyright = "2023, Smartly Dressed Games"
 author = "Smartly Dressed Games"
 
-version = "3"
+version = "3.x"
 release = version
 
 # -- General configuration
@@ -24,6 +24,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinxext.opengraph', # OpenGraph support (e.g., URLs posted onto our Discourse forum will appear as OneBox embeds)
     'sphinx_rtd_theme', # "Read the Docs Sphinx Theme" https://sphinx-rtd-theme.readthedocs.io/en/stable/index.html
+    'sphinx_tabs.tabs',
     # -- Locally-installed modules
     'unturned_lexer',
 ]

--- a/data/asset-ptr.rst
+++ b/data/asset-ptr.rst
@@ -11,7 +11,7 @@ In \*.dat files
 Note that the GUID here is not wrapped in quotes because Unturned \*.dat files are treated as pairs of strings.
 
 .. code-block:: unturneddat
-	
+
 	MyAssetPtr ################################
 
 In \*.asset files
@@ -20,7 +20,7 @@ In \*.asset files
 Two formats are supported in these files. The inline style was added later so you will see the older style used in many official assets.
 
 .. code-block:: unturnedasset
-	
+
 	"MyAssetPtr" "################################"
 	"MyAssetPtr" { "GUID" "################################" }
 
@@ -28,5 +28,5 @@ In JSON files
 -------------
 
 .. code-block:: json
-	
+
 	"MyAssetPtr": { "GUID": "################################" }

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@ sphinx==6
 sphinx_rtd_theme
 sphinxext-opengraph
 matplotlib
+sphinx-tabs

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ docutils==0.19
     # via
     #   sphinx
     #   sphinx-rtd-theme
+    #   sphinx-tabs
 fonttools==4.53.1
     # via matplotlib
 idna==3.7
@@ -51,7 +52,9 @@ packaging==24.1
 pillow==10.4.0
     # via matplotlib
 pygments==2.18.0
-    # via sphinx
+    # via
+    #   sphinx
+    #   sphinx-tabs
 pyparsing==3.1.2
     # via matplotlib
 python-dateutil==2.9.0.post0
@@ -68,9 +71,12 @@ sphinx==6.0.0
     # via
     #   -r requirements.in
     #   sphinx-rtd-theme
+    #   sphinx-tabs
     #   sphinxcontrib-jquery
     #   sphinxext-opengraph
 sphinx-rtd-theme==2.0.0
+    # via -r requirements.in
+sphinx-tabs==3.4.5
     # via -r requirements.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx


### PR DESCRIPTION
This PR does three things:

- Updates the README steps for building the docs locally. We can close out #327 if this is merged.

- Enables offline, zipped HTML downloads (alternative to PDF and EPUB3).

- Reenables sphinx-tabs extension (dropped due to deprecation of Sphinx content injection). This hasn't broken anything now, but it's a popular extension that we may want to use when showing multiple code examples. E.g., .dat vs .asset vs json format, inline vs object, multiple examples (of the same language), etc.