### PR TITLE
Increment Sphinx version, add "Copy" button

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@
 
 version: 2
 
-# Enabling PDF and EPUB builds, for offline use (unsure why HTMLzip fails to build)
+# Build PDF and ePub versions for offline use (HTMLzip might be too big to build?)
 formats:
   - epub
   - pdf

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The built documentation is hosted by [Read the Docs](https://readthedocs.org/) h
 Offline Downloads
 -----------------
 
-PDF, ePub, and zipped HTML versions of the documentation can be [downloaded](https://readthedocs.org/projects/unturned/downloads/) for offline use.
+PDF and ePub versions of the documentation can be [downloaded](https://readthedocs.org/projects/unturned/downloads/) for offline use.
 
 Contributing
 ------------

--- a/assets/crafting-blacklist-asset.rst
+++ b/assets/crafting-blacklist-asset.rst
@@ -17,13 +17,13 @@ Prevents specific items or blueprints from being used while crafting. They are h
 	[
 		// Orange Hoodie
 		"GUID" "67c76cdf16024bf68b6e5d14d4c617ab"
-		
+
 		// Individual items can also be enclosed in brackets { }
 		{
 			// Eaglefire
 			GUID b03d581a5c1a490f995f8deba57b0f17
 		}
-		
+
 		// Jeans
 		dab78cc4d66645bfb8169be7c15cf876
 		55c69817a31448b685c7f788ec7d2d0c

--- a/conf.py
+++ b/conf.py
@@ -21,6 +21,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel', # create explicit targets for all sections in the form of {path/to/page}:{title-of-section}
     'sphinx.ext.autosummary',
+    'sphinx_copybutton',
     'sphinx.ext.intersphinx',
     'sphinxext.opengraph', # OpenGraph support (e.g., URLs posted onto our Discourse forum will appear as OneBox embeds)
     'sphinx_rtd_theme', # "Read the Docs Sphinx Theme" https://sphinx-rtd-theme.readthedocs.io/en/stable/index.html

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,8 @@
-sphinx==6
+sphinx==6.2.1
 sphinx_rtd_theme
-sphinxext-opengraph
-matplotlib
+
+sphinx-copybutton
 sphinx-tabs
+sphinxext-opengraph
+
+matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,13 +67,16 @@ six==1.16.0
     # via python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==6.0.0
+sphinx==6.2.1
     # via
     #   -r requirements.in
+    #   sphinx-copybutton
     #   sphinx-rtd-theme
     #   sphinx-tabs
     #   sphinxcontrib-jquery
     #   sphinxext-opengraph
+sphinx-copybutton==0.5.2
+    # via -r requirements.in
 sphinx-rtd-theme==2.0.0
     # via -r requirements.in
 sphinx-tabs==3.4.5


### PR DESCRIPTION
- Upgrade Sphinx version from 6.0.0 to **6.2.1**.

- Removes mention of HTMLzip from the README, as this is no longer available for offline download. I don't think the Sphinx upgrade will fix the build errors we were receiving, so I haven't attempted reenabling the format for this PR.

- Adds the sphinx-copybutton extension. This adds a "Copy" button to all code-blocks. https://sphinx-copybutton.readthedocs.io/en/latest/

![image](https://github.com/user-attachments/assets/2598f2d8-9f4e-4ee8-ba0b-53cb92165a77)

![image](https://github.com/user-attachments/assets/b97c7cc9-0273-47c3-92e5-4e8314b28c1d)
