### PR TITLE
Remove mentions of Devkit

### DIFF
--- a/assets/npc-asset/rewards.rst
+++ b/assets/npc-asset/rewards.rst
@@ -208,7 +208,7 @@ Player Spawnpoint
 
 **Reward_#_Type** *enum* (``Player_Spawnpoint``)
 
-**Reward_#_ID** *string* Override the player's default spawn location, using the spawnpoint name set in the Devkit level editor or a map location node name. For example, ``Liberator_Jet``. Saved and loaded between sessions. If empty, the override is removed and the default spawns are used. The ``SetNpcSpawnId`` admin command is useful for testing this.
+**Reward_#_ID** *string* Override the player's default spawn location, using the ID of a spawnpoint node or the name of a map location node, as set in the level editor. For example, ``Liberator_Jet``. Saved and loaded between sessions. If empty, the override is removed and the default spawns are used. The ``SetNpcSpawnId`` admin command is useful for testing this.
 
 .. hint:: On the Buak map, the player can talk with Kira to claim a room in the Factory using this reward type.
 
@@ -238,7 +238,7 @@ Teleport
 
 **Reward_#_Type** *enum* (``Teleport``)
 
-**Reward_#_Spawnpoint** *string*: Location to teleport the player to as a reward, using the spawnpoint name as set in the Devkit level editor. For example, ``Liberator_Jet``.
+**Reward_#_Spawnpoint** *string*: Location to teleport the player to as a reward, using the ID of a spawnpoint node as set in the level editor. For example, ``Liberator_Jet``.
 
 Vehicle
 ```````
@@ -247,7 +247,7 @@ Vehicle
 
 **Reward_#_ID** : ID of Vehicle to be given.
 
-**Reward_#_Spawnpoint** *string*: Location to spawn the vehicle in as a reward, using the spawnpoint name as set in the Devkit level editor. For example, ``Liberator_Jet``.
+**Reward_#_Spawnpoint** *string*: Location to spawn the vehicle in as a reward, using the ID of a spawnpoint node as set in the level editor. For example, ``Liberator_Jet``. If an ID is not provided, the vehicle will spawn above the NPC.
 
 **Reward_#_PaintColor** *color*: If set, overrides color of spawned vehicle. Vehicle redirector asset's ``SpawnPaintColor`` and vehicle asset's ``DefaultPaintColors`` are bypassed.
 

--- a/assets/npc-asset/vendor-asset.rst
+++ b/assets/npc-asset/vendor-asset.rst
@@ -33,7 +33,7 @@ Properties pertaining to items or vehicles that the vendor is willing to sell to
 
 **Selling_#_Cost** *uint32*: Amount of currency to pay the vendor. Defaults to experience points as the currency, unless the Currency property has been set.
 
-**Selling_#_Spawnpoint** *string*: Location to spawn the purchased vehicle, using the spawnpoint name as set in the Devkit level editor. For example, ``Liberator_Jet``.
+**Selling_#_Spawnpoint** *string*: Location to spawn the purchased vehicle, using the ID of a spawnpoint node as set in the level editor. For example, ``Liberator_Jet``. If an ID is not provided, the vehicle will spawn above the NPC.
 
 **Selling_#_PaintColor** *color*: If set, overrides color of purchased vehicle. Vehicle redirector asset's ``SpawnPaintColor`` and vehicle asset's ``DefaultPaintColors`` are bypassed.
 

--- a/mapping/level-config.rst
+++ b/mapping/level-config.rst
@@ -89,9 +89,9 @@ General
 
 **Use_Legacy_Clip_Borders** *bool*: Should invisible walls matching map size be created? Defaults to true.
 
-**Use_Legacy_Ground** *bool*: Should default terrain be created? Alternative is to use devkit landscape tiles. Defaults to true.
+**Use_Legacy_Ground** *bool*: Should default terrain be created? Alternative is to use landscape tiles. Defaults to true.
 
-**Use_Legacy_Water** *bool*: Should global water plane be enabled? Alternative is to use water volumes in devkit. Defaults to true.
+**Use_Legacy_Water** *bool*: Should global water plane be enabled? Alternative is to use water volumes. Defaults to true.
 
 **Use_Vanilla_Bubbles** *bool*: Should vanilla water bubble effects be enabled? Defaults to true.
 


### PR DESCRIPTION
Removes/replaces most references to the Devkit, as per https://github.com/SmartlyDressedGames/Unturned-Docs/issues/364.