### PR TITLE
SalvageItem cannot point to spawntables

### DIFF
--- a/assets/item-asset/placeable-asset.rst
+++ b/assets/item-asset/placeable-asset.rst
@@ -16,4 +16,4 @@ Placeable Asset Properties
 
 **Max_Items_Dropped_On_Destroy** *int*: Maximum number of items to drop when destroyed. Defaults to 0.
 
-**SalvageItem** :ref:`Asset Pointer <doc_data_assetptr>`: Item added when picking up below 100% health. Defaults to a random item used in the placeable's blueprints.
+**SalvageItem** :ref:`Asset Pointer <doc_data_assetptr>`: Override the default salvaging behavior by pointing to a specific item that should be added when salvaging a placeable that is below 100% health. This property cannot point to a :ref:`SpawnAsset <doc_assets_spawn>` – only :ref:`ItemAssets <doc_item_asset_intro>` are supported. By default, this property will choose a random item used in the placeable's blueprints.


### PR DESCRIPTION
Better emphasizes that only _items_ can be specified -- with no support for tables. Should reduce confusion.