### PR TITLE
Link to "new map curation program" announcement

### DIFF
--- a/assets/asset-bundles.rst
+++ b/assets/asset-bundles.rst
@@ -8,7 +8,7 @@ The game loads textures, audio, meshes, prefabs, etc. from **Unity Asset Bundles
 \*.content bundles to
 \*.masterbundle files.
 
-:ref:`Master Bundles <doc_asset_bundles:master_bundles>` should be used for essentially all new projects.
+:ref:`Master bundles <doc_asset_bundles:master_bundles>` should be used for essentially all new projects.
 
 Tool Setup
 ----------
@@ -25,17 +25,19 @@ Prior to using any of these tools they must be imported into a Unity project
 Master Bundles
 --------------
 
-Most official files including curated maps have been transitioned to master bundles (\*.masterbundle), and they will be used for the forseeable future.
+Master bundles are the most efficient way for your assets to be packaged and distributed. They should be used for essentially any project that you plan to share with other players.
 
-File Setup for Master Bundles
-`````````````````````````````
+There are only a few asset types that are unsupported by master bundles.
+
+File Setup
+``````````
 
 Master bundles can be loaded from any directory the game loads \*.dat files from. Unless an override is specified, the nearest master bundle in the file hierarchy is used. While loading each directory is checked for a MasterBundle.dat file signalling the presence of a master bundle. For example, refer to the core.masterbundle in the Bundles directory.
 
 MasterBundle.dat can set the following keys:
 
 .. code-block:: unturneddat
-	
+
 	// Name of asset bundle file in the same directory as MasterBundle.dat.
 	Asset_Bundle_Name core.masterbundle
 
@@ -49,7 +51,7 @@ MasterBundle.dat can set the following keys:
 Individual asset \*.dats can set the following keys:
 
 .. code-block:: unturneddat
-	
+
 	// Name of master bundle to load files from.
 	Master_Bundle_Override core.masterbundle
 
@@ -60,8 +62,8 @@ Individual asset \*.dats can set the following keys:
 	// Used by notes to share a common object prefab.
 	Bundle_Override_Path /Objects/Medium/Furniture/Note
 
-Tool Usage for Master Bundles
-`````````````````````````````
+Tool Usage
+``````````
 
 1. Follow *Tool Setup* instructions.
 2. Open the tool from the Window > Unturned > Master Bundle Tool menu.
@@ -72,18 +74,22 @@ Tool Usage for Master Bundles
 7. Click Export.
 8. (optional) When redistributing the asset bundle the "multiplatform" toggle should be enabled. This ensures the appropriate shaders for each platform are included, and exports a ".hash" file so the server can validate client asset bundle integrity.
 
-Motivations for Master Bundles
-``````````````````````````````
+Motivations
+```````````
 
 When upgrading to Unity 2017.4 LTS it became apparent that all asset bundles would have to be re-exported from Unity due to shader compatibility changes. This would be an incredible amount of files, so it was time to re-approach the \*.content issue in a way that could quickly convert all existing content. This was handled by keeping the file hierarchy 1:1 and guessing the file extension for the by-name loading.
 
 Individual Asset Bundles
 ------------------------
 
-Most official files have transitioned to the master bundle system, but some use individual asset bundles (\*.unity3d). For example, the per-map road textures.
+Most official files have transitioned to the master bundle system, but some use individual asset bundles (\*.unity3d). For example:
 
-Tool Usage for Asset Bundles
-````````````````````````````
+- Per-map road textures.
+- Colors used by charts.
+- Level ambience.
+
+Tool Usage
+``````````
 
 1. Follow *Tool Setup* instructions.
 2. Open the tool from the Window > Unturned > Bundle Tool menu.
@@ -91,8 +97,8 @@ Tool Usage for Asset Bundles
 4. Click Grab to preview which assets will be exported.
 5. Click Bundle to choose a destination for the asset bundle file.
 
-Motivations for Asset Bundles
-`````````````````````````````
+Motivations
+```````````
 
 When beginning development of 3.0, it was key to support runtime loading of custom modded content. At the time files in asset bundles were loaded by name without extension, so each game type looked for specific names like "Item", "Object", "Animal", etc. The .unity3d extension was chosen for web browser compatibility. Obviously this system did not age well.
 

--- a/index.rst
+++ b/index.rst
@@ -167,7 +167,7 @@ Upcoming Features
 
 You can find modding features under consideration on this Trello board: `Unturned Roadmap <https://trello.com/b/gpe4zlW3/unturned-roadmap>`_. The cards on the board aren't ordered in any particular way. i.e., they do not dictate the order of updates.
 
-Miscellaneous requests and tasks that may pop up take priority over the roadmap, so it may go a while between progress updates. For example, work for curated maps often takes priority. Several high-priority ideas that don't yet have a solid plan, like a crafting revamp, are not listed on the board.
+Miscellaneous requests and tasks that may pop up take priority over the roadmap, so it may go a while between progress updates. Several high-priority ideas that don't yet have a solid plan, like a crafting revamp, are not listed on the board.
 
 Legacy Tutorials
 ----------------

--- a/mapping/curated-maps.rst
+++ b/mapping/curated-maps.rst
@@ -3,7 +3,7 @@
 Curated Maps
 ============
 
-.. important:: **Note**: We are not currently processing new curated map submissions or update proposals as our queue is full. We encourage you to focus on enjoying the development of your map rather than aiming solely for curated status. Creating a map is intended as a fun and rewarding hobby!
+.. important:: The **Map Curation Program** is changing! We've already `announced some of our plans <https://steamcommunity.com/app/304930/discussions/0/601894864482792245/>`_. Creating a map is intended to be a fun and rewarding hobby! Documentation will be updated as we shift towards this new program.
 
 Community-created maps that are officially linked from the game are considered **Curated Maps**. They help players find high-quality new experiences, and keep the game updated with fresh content. Modders can then earn money from their work on their hobby, and get their creations highlighted.
 


### PR DESCRIPTION
Links to program announcement and removes some older text about curation.

Could update Roadmap w/ cards for these recent announcements.

Think we'll want to eventually move all program info (e.g. FAQ) into Docs. In "Curated Maps" or a new page under ABOUT tocsection.