### PR TITLE
More keywords in asset documentation

### DIFF
--- a/items/backpack-asset.rst
+++ b/items/backpack-asset.rst
@@ -3,7 +3,7 @@
 Backpack Assets
 ===============
 
-The ItemBackpackAsset class is used by clothing items occupying the "backpack" slot. Backpacks can be worn by players and zombies.
+Backpacks are created from the ItemBackpackAsset class. They can be worn by players and zombies, and occupy the player's "backpack" slot.
 
 Game Data File
 --------------
@@ -13,16 +13,16 @@ The ItemBackpackAsset class inherits properties from the :ref:`ItemBagAsset <doc
 .. list-table::
    :widths: 30 40 30
    :header-rows: 1
-   
+
    * - Class
      - Property Name
      - Required Value
    * - :ref:`ItemAsset <doc_item_asset_intro>`
      - :ref:`GUID <doc_item_asset_intro:guid>`
-     - 
+     -
    * - :ref:`ItemAsset <doc_item_asset_intro>`
      - :ref:`ID <doc_item_asset_intro:id>`
-     - 
+     -
    * - :ref:`ItemAsset <doc_item_asset_intro>`
      - :ref:`Type <doc_item_asset_intro:type>`
      - ``Backpack``

--- a/items/barrel-asset.rst
+++ b/items/barrel-asset.rst
@@ -3,7 +3,7 @@
 Barrel Assets
 =============
 
-Barrel attachments are inventory items that can be attached to ranged weapons.
+Barrels (or "barrel attachments") are created from the ItemBarrelAsset class. Barrel attachments are inventory items that can be attached to ranged weapons.
 
 This inherits the :ref:`CaliberAsset <doc_item_asset_caliber>` class.
 

--- a/items/barricade-asset.rst
+++ b/items/barricade-asset.rst
@@ -3,7 +3,7 @@
 Barricade Assets
 ================
 
-Barricades can be placed by players.
+Barricades are created from the ItemBarricadeAsset class. They can be placed by players or in the level editor.
 
 This inherits the :ref:`PlaceableAsset <doc_item_asset_placeable>` class.
 

--- a/items/beacon-asset.rst
+++ b/items/beacon-asset.rst
@@ -3,7 +3,7 @@
 Beacon Assets
 =============
 
-Beacons are a placeable zombie horde spawners. Placing the beacon will start a horde event, which can be completed by killing a certain number of zombies without letting the beacon be destroyed.
+Beacons are created from the ItemBeaconAsset class. Placing the beacon will start a zombie horde event, which can be completed by killing a predetermined number of zombies before the beacon is destroyed.
 
 This inherits the :ref:`BarricadeAsset <doc_item_asset_barricade>` class.
 

--- a/items/box-asset.rst
+++ b/items/box-asset.rst
@@ -3,7 +3,7 @@
 Box Assets
 ==========
 
-Boxes are intended to be used as a part of the Steam Economy, rather than as in-game content. As such, none of its unique properties can be properly utilized by modders.
+Boxes are created from the ItemBoxAsset class. They are used to visualize certain information from the game's Steam Economy integration. Since this asset is not useful to modders, this documentation merely exists for completeness.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 
@@ -25,7 +25,7 @@ Box Asset Properties
 
 **Drops** *int32*: Corresponds to the total number of items in the box, so that the correct number of UI elements are displayed when showing box contents.
 
-**Drop\_#** *int32*: The itemdefid of an item in the box, which is visually displayed as a UI element when showing box contents.
+**Drop_#** *int32*: The itemdefid of an item in the box, which is visually displayed as a UI element when showing box contents.
 
 **Item_Origin** *enum* (``Unbox``, ``Unwrap``): The localization key to use for for the unbox/unwrap menu button.
 

--- a/items/charge-asset.rst
+++ b/items/charge-asset.rst
@@ -3,7 +3,7 @@
 Charge Assets
 =============
 
-Remote explosives can be placed and then remotely detonated with a :ref:`remote trigger <doc_item_asset_detonator>`.
+Charges (or "remote explosives") are created from the ItemChargeAsset class. They can be placed and then remotely detonated with a :ref:`remote trigger <doc_item_asset_detonator>`.
 
 This inherits the :ref:`BarricadeAsset <doc_item_asset_barricade>` class.
 

--- a/items/cloud-asset.rst
+++ b/items/cloud-asset.rst
@@ -3,7 +3,7 @@
 Cloud Assets
 ============
 
-Parachutes can affect a player's gravity when held.
+Clouds (or "parachutes") are created from the ItemCloudAsset class. They can affect a player's gravity when held.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/detonator-asset.rst
+++ b/items/detonator-asset.rst
@@ -3,7 +3,7 @@
 Detonator Assets
 ================
 
-Remote triggers can be used to detonate :ref:`remote explosives <doc_item_asset_charge>`.
+Detonators (or "remote triggers") are created from the ItemDetonatorAsset class. They can be used to detonate :ref:`remote explosives <doc_item_asset_charge>`.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/farm-asset.rst
+++ b/items/farm-asset.rst
@@ -3,7 +3,9 @@
 Farm Assets
 ===========
 
-Farms (localized as "plants") are a placeable seeds capable of growing into harvestable crops. When a seed is planted, it will grow over time until eventually harvestable. Growing can be finished immediately by either rainfall, or by using a :ref:`growth supplement <doc_item_asset_grower>` on the plant. A fully-grown crop can be harvested, which deals 2 damage to the crop. A crop can be harvested until it has 0 health remaining.
+Farms (or "plants") are created from the ItemFarmAsset class. They are placeable seeds capable of growing into harvestable crops.
+
+When a seed is planted, it will grow over time until eventually harvestable. Growing can be finished immediately by either rainfall, or by using a :ref:`growth supplement <doc_item_asset_grower>` on the plant. A fully-grown crop can be harvested, which deals 2 damage to the crop. A crop can be harvested until it has 0 health remaining.
 
 This inherits the :ref:`BarricadeAsset <doc_item_asset_barricade>` class.
 
@@ -42,5 +44,5 @@ Farm Asset Properties
 **Harvest_Rewards**: NPC reward list granted when harvesting the grown plant. For more information, please refer to the :ref:`Rewards <doc_npc_asset_rewards>` documentation.
 
 .. tip::
-	
+
 	The ``Health`` property from the parent ItemAsset class can be configured to allow for harvesting a crop multiple times. A plant can be harvested a number of items equal to ``Health / 2``. For example, a plant with 10 health can be harvested up to 5 times.

--- a/items/filter-asset.rst
+++ b/items/filter-asset.rst
@@ -3,7 +3,7 @@
 Filter Assets
 =============
 
-Radiation filters can be used to replenish the quality of radiation-proof :ref:`masks <doc_item_asset_mask>`.
+Filters (or "radiation filters") are created from the ItemFilterAsset class. They can be used to replenish the quality of radiation-proof :ref:`masks <doc_item_asset_mask>`.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/fisher-asset.rst
+++ b/items/fisher-asset.rst
@@ -3,7 +3,7 @@
 Fisher Assets
 =============
 
-Fishers (localized as "fishing poles") are useables that allow for catching fish.
+Fishers (or "fishing poles") are created from the ItemFisherAsset class. They are useables that allow for catching fish.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/food-asset.rst
+++ b/items/food-asset.rst
@@ -3,7 +3,7 @@
 Food Assets
 ===========
 
-Food is irreversibly consumed by the player on use, and directly affect a player's stats such as food or health.
+Food items are created from the ItemFoodAsset class. They can be consumed by the player.
 
 This inherits the :ref:`ConsumeableAsset <doc_item_asset_consumeable>` class.
 

--- a/items/fuel-asset.rst
+++ b/items/fuel-asset.rst
@@ -3,7 +3,7 @@
 Fuel Assets
 ===========
 
-Fuel canisters are useables able to siphon, store, and deposit fuel.
+Fuel items (or "fuel canisters") are created from the ItemFuelAsset class. They are useables able to siphon, store, and deposit fuel.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/generator-asset.rst
+++ b/items/generator-asset.rst
@@ -3,7 +3,7 @@
 Generator Assets
 ================
 
-Generators are a placeable power sources. Players can deposit fuel into generators with a :ref:`fuel canister <doc_item_asset_fuel>`.
+Generators are created from the ItemGeneratorAsset class. They are a placeable power sources. Players can deposit fuel into generators with a :ref:`fuel canister <doc_item_asset_fuel>`.
 
 This inherits the :ref:`BarricadeAsset <doc_item_asset_barricade>` class.
 

--- a/items/glasses-asset.rst
+++ b/items/glasses-asset.rst
@@ -3,7 +3,7 @@
 Glasses Assets
 ==============
 
-Glasses can be worn by players and zombies.
+Glasses are created from ItemGlassesAsset. They are clothing items that can be worn by players and zombies.
 
 This inherits the :ref:`GearAsset <doc_item_asset_gear>` class.
 

--- a/items/grip-asset.rst
+++ b/items/grip-asset.rst
@@ -3,7 +3,7 @@
 Grip Assets
 ===========
 
-Grip attachments are inventory items that can be attached to ranged weapons.
+Grips (or "grip attachments") are created from the ItemGripAsset class. They are inventory items that can be attached to ranged weapons.
 
 This inherits the :ref:`CaliberAsset <doc_item_asset_caliber>` class.
 

--- a/items/grower-asset.rst
+++ b/items/grower-asset.rst
@@ -3,7 +3,7 @@
 Grower Assets
 =============
 
-Growth supplements can be used to instantly finish growing a :ref:`plant <doc_item_asset_farm>`.
+Growers (or "growth supplements") are created from the ItemGrowerAsset class. They can be used to instantly finish growing a :ref:`plant <doc_item_asset_farm>`.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/introduction.rst
+++ b/items/introduction.rst
@@ -3,7 +3,7 @@
 Introduction to Items
 =====================
 
-Items in *Unturned* encompass anything that can be carried in a player's in-game inventory. All items will share certain properties, but each item type may have its own unique properties as well. Please refer to :ref:`Asset Definitions <doc_asset_definitions>` and :ref:`Asset Bundles <doc_asset_bundles>` for the full documentation regarding assets and asset bundles.
+Items are created from the ItemAsset class. They encompass anything that can be carried in a player's in-game inventory. All items will share certain properties, but each item type may have its own unique properties as well. Please refer to :ref:`Asset Definitions <doc_asset_definitions>` and :ref:`Asset Bundles <doc_asset_bundles>` for the full documentation regarding assets and asset bundles.
 
 Unity Asset Bundle Contents
 ---------------------------

--- a/items/key-asset.rst
+++ b/items/key-asset.rst
@@ -3,7 +3,7 @@
 Key Assets
 ==========
 
-Keys are intended to be used as a part of the Steam Economy, rather than as in-game content. As such, none of its unique properties can be properly utilized by modders.
+Keys are created from the ItemKeyAsset class. They are intended to be used as a part of the Steam Economy, rather than as in-game content. As such, none of its unique properties can be properly utilized by modders.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/library-asset.rst
+++ b/items/library-asset.rst
@@ -3,7 +3,7 @@
 Library Assets
 ==============
 
-Libraries are placeable storage containers for experience points.
+Libraries are created from the ItemLibraryAsset class. They are placeable storage containers for experience points.
 
 This inherits the :ref:`BarricadeAsset <doc_item_asset_barricade>` class.
 

--- a/items/magazine-asset.rst
+++ b/items/magazine-asset.rst
@@ -3,7 +3,7 @@
 Magazine Assets
 ===============
 
-Magazine attachments are inventory items that can be attached to ranged weapons.
+Magazines (or "magazine attachments") are created from the ItemMagazineAsset class. They can be attached to ranged weapons.
 
 This inherits the :ref:`CaliberAsset <doc_item_asset_caliber>` class.
 
@@ -15,16 +15,16 @@ Magazine attachments inherit properties from the CaliberAsset class, which in tu
 .. list-table::
    :widths: 30 40 30
    :header-rows: 1
-   
+
    * - Class
      - Property Name
      - Required Value
    * - :ref:`ItemAsset <doc_item_asset_intro>`
      - :ref:`GUID <doc_item_asset_intro:guid>`
-     - 
+     -
    * - :ref:`ItemAsset <doc_item_asset_intro>`
      - :ref:`ID <doc_item_asset_intro:id>`
-     - 
+     -
    * - :ref:`ItemAsset <doc_item_asset_intro>`
      - :ref:`Type <doc_item_asset_intro:type>`
      - ``Magazine``
@@ -35,7 +35,7 @@ Properties
 .. list-table::
    :widths: 40 40 20
    :header-rows: 1
-   
+
    * - Property Name
      - Type
      - Default Value
@@ -47,7 +47,7 @@ Properties
      - ``0``
    * - :ref:`Delete_Empty <doc_item_asset_magazine:delete_empty>`
      - :ref:`flag <doc_data_flag>`
-     - 
+     -
    * - :ref:`Explosion <doc_item_asset_magazine:explosion>`
      - :ref:`doc_data_guid` or :ref:`uint16 <doc_data_builtin_types>`
      - ``0``
@@ -56,7 +56,7 @@ Properties
      - See description
    * - :ref:`Explosive <doc_item_asset_magazine:explosive>`
      - :ref:`flag <doc_data_flag>`
-     - 
+     -
    * - :ref:`Impact <doc_item_asset_magazine:impact>`
      - :ref:`doc_data_guid` or :ref:`uint16 <doc_data_builtin_types>`
      - ``0``
@@ -89,7 +89,7 @@ Properties
      - ``false``
    * - :ref:`Spawn_Explosion_On_Dedicated_Server <doc_item_asset_magazine:spawn_explosion_on_dedicated_server>`
      - :ref:`flag <doc_data_flag>`
-     - 
+     -
    * - :ref:`Speed <doc_item_asset_magazine:speed>`
      - :ref:`float32 <doc_data_builtin_types>`
      - ``1``

--- a/items/map-asset.rst
+++ b/items/map-asset.rst
@@ -3,7 +3,7 @@
 Map Assets
 ==========
 
-Maps and compasses provide the player with additional UI information for as long as they are in the player's inventory. They can neither be held nor equipped.
+Maps and compasses are created from the ItemMapAsset class. They provide the player with additional UI information for as long as they are in the player's inventory. They can neither be held nor equipped.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/mask-asset.rst
+++ b/items/mask-asset.rst
@@ -3,7 +3,7 @@
 Mask Assets
 ===========
 
-Masks can be worn by players and zombies.
+Masks are created from the ItemMaskAsset class. They can be worn by players and zombies.
 
 This inherits the :ref:`GearAsset <doc_item_asset_gear>` class.
 

--- a/items/medical-asset.rst
+++ b/items/medical-asset.rst
@@ -3,7 +3,7 @@
 Medical Assets
 ==============
 
-Medicine is irreversibly consumed by the player on use, and directly affect a player's stats such as health or immunity.
+Medical items (or "medicine") are created from the ItemMedicalAsset class. They are irreversibly consumed by the player on use, and directly affect a player's stats such as health or immunity.
 
 This inherits the :ref:`ConsumeableAsset <doc_item_asset_consumeable>` class.
 

--- a/items/melee-asset.rst
+++ b/items/melee-asset.rst
@@ -3,7 +3,7 @@
 Melee Assets
 ============
 
-Melee weapons can be used as a source of damage. Melee weapons always show quality.
+Melees (or "melee weapons") are created from the ItemMeleeAsset class. They can be used as a source of damage. Melee weapons always show quality.
 
 This inherits the :ref:`WeaponAsset <doc_item_asset_weapon>` class.
 
@@ -29,7 +29,7 @@ Melee Asset Properties
 
 **ImpactAudioDef** :ref:`Master Bundle Pointer <doc_data_masterbundleptr>`: AudioClip or OneShotAudioDefinition to play upon impact.
 
-**Light** *flag*: Provides a toggleable flashlight, and allows for using :ref:`PlayerSpotLightConfig <doc_data_playerspotlightconfig>` properties. 
+**Light** *flag*: Provides a toggleable flashlight, and allows for using :ref:`PlayerSpotLightConfig <doc_data_playerspotlightconfig>` properties.
 
 **Repair** *flag*: Repairs barricades, structures, and vehicles.
 

--- a/items/oil-pump-asset.rst
+++ b/items/oil-pump-asset.rst
@@ -3,7 +3,7 @@
 Oil Pump Assets
 ===============
 
-Oil pumps are placeables capable of creating fuel. When powered, oil pumps generate fuel over time.
+Oil pumps are created from the ItemOilPumpAsset class. They are placeables capable of creating fuel. When powered, oil pumps generate fuel over time.
 
 This inherits the :ref:`BarricadeAsset <doc_item_asset_barricade>` class.
 

--- a/items/optic-asset.rst
+++ b/items/optic-asset.rst
@@ -3,7 +3,7 @@
 Optic Assets
 ============
 
-Optics can modify a player's view.
+Optics are created from the ItemOpticAsset class. They can modify a player's view.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/pants-asset.rst
+++ b/items/pants-asset.rst
@@ -3,7 +3,7 @@
 Pants Assets
 ============
 
-Pants can be worn by players and zombies.
+Pants are created from the ItemPantsAsset class. They can be worn by players and zombies.
 
 This inherits the :ref:`BagAsset <doc_item_asset_bag>` class.
 

--- a/items/placeable-asset.rst
+++ b/items/placeable-asset.rst
@@ -3,7 +3,7 @@
 Placeable Assets
 ================
 
-Placeables are able to be placed by players.
+The ItemPlaceableAsset class is a base class that other classes are derived from. Placeables are able to be placed by players.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/refill-asset.rst
+++ b/items/refill-asset.rst
@@ -3,7 +3,7 @@
 Refill Assets
 =============
 
-Refills (localized as "water canisters") are useables able to siphon, store, and deposit water. Players can also drink from water canisters in order to restore their status bars. Water canisters have four potential states: empty, salty, dirty, or clean.
+Refills (localized as "water canisters") are created from the ItemRefillAsset class. They are useables able to siphon, store, and deposit water. Players can also drink from water canisters in order to restore their status bars. Water canisters have four potential states: empty, salty, dirty, or clean.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/sentry-asset.rst
+++ b/items/sentry-asset.rst
@@ -3,7 +3,7 @@
 Sentry Assets
 =============
 
-Sentries (localized as "robotic turrets") are placeables that can automatically detect, track, and attack target under certain conditions. Storing a ranged weapon inside a sentry allows it to use that weapon when attacking target.
+Sentries (localized as "robotic turrets") are created from the ItemSentryAsset class. They are placeables that can automatically detect, track, and attack target under certain conditions. Storing a ranged weapon inside a sentry allows it to use that weapon when attacking target.
 
 This inherits the :ref:`StorageAsset <doc_item_asset_storage>` class.
 

--- a/items/shirt-asset.rst
+++ b/items/shirt-asset.rst
@@ -3,7 +3,7 @@
 Shirt Assets
 ============
 
-Shirts can be worn by players and zombies.
+Shirts are created from the ItemShirtAsset class. They can be worn by players and zombies.
 
 This inherits the :ref:`BagAsset <doc_item_asset_bag>` class.
 

--- a/items/sight-asset.rst
+++ b/items/sight-asset.rst
@@ -3,7 +3,7 @@
 Sight Assets
 ============
 
-Sight attachments are inventory items that can be attached to ranged weapons.
+Sights (or "sight attachments") are created from the ItemSightAsset class. They are inventory items that can be attached to ranged weapons.
 
 This inherits the :ref:`CaliberAsset <doc_item_asset_caliber>` class.
 

--- a/items/storage-asset.rst
+++ b/items/storage-asset.rst
@@ -3,7 +3,7 @@
 Storage Assets
 ==============
 
-Storages (localized as "item storages") are placeables used to store items.
+Storages (localized as "item storages") are created from the ItemStorageAsset class. They are placeables used to store items.
 
 This inherits the :ref:`BarricadeAsset <doc_item_asset_barricade>` class.
 

--- a/items/structure-asset.rst
+++ b/items/structure-asset.rst
@@ -3,7 +3,7 @@
 Structure Assets
 ================
 
-Structures can be placed by players. Some structure pieces require another structure piece in order to be placed.
+Structures are created from the ItemStructureAsset class. They can be placed by players. Some structure pieces require another structure piece in order to be placed.
 
 This inherits the :ref:`PlaceableAsset <doc_item_asset_placeable>` class.
 

--- a/items/supply-asset.rst
+++ b/items/supply-asset.rst
@@ -3,7 +3,7 @@
 Supply Assets
 =============
 
-Crafting supplies are items primarily intended to be used as ingredients in crafting blueprints. They can neither be held nor equipped.
+Supplies (or "crafting supplies") are created from the ItemSupplyAsset class. They are items primarily intended to be used as ingredients in crafting blueprints. They can neither be held nor equipped.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/tactical-asset.rst
+++ b/items/tactical-asset.rst
@@ -3,7 +3,7 @@
 Tactical Assets
 ===============
 
-Tactical attachments are inventory items that can be attached to ranged weapons.
+Tacticals (or "tactical attachments") are created from the ItemTacticalAsset class. They are inventory items that can be attached to ranged weapons.
 
 This inherits the :ref:`CaliberAsset <doc_item_asset_caliber>` class.
 

--- a/items/tank-asset.rst
+++ b/items/tank-asset.rst
@@ -3,7 +3,7 @@
 Tank Assets
 ===========
 
-Tanks (localized as "liquid storages") are placeables used to store water or fuel. Players can siphon from, or deposit into, a liquid storage with certain items. Fuel tanks require a :ref:`fuel canister <doc_item_asset_fuel>`, while water tanks require a :ref:`water canister <doc_item_asset_refill>`.
+Tanks (localized as "liquid storages") are created from the ItemTankAsset class. They are placeables used to store water or fuel. Players can siphon from, or deposit into, a liquid storage with certain items. Fuel tanks require a :ref:`fuel canister <doc_item_asset_fuel>`, while water tanks require a :ref:`water canister <doc_item_asset_refill>`.
 
 This inherits the :ref:`BarricadeAsset <doc_item_asset_barricade>` class.
 

--- a/items/throwable-asset.rst
+++ b/items/throwable-asset.rst
@@ -3,7 +3,7 @@
 Throwable Assets
 ================
 
-Throwables can be thrown by players. Throwables cannot be used in any safezones that disallow weapons.
+Throwables are created from the ItemThrowableAsset class. They can be thrown by players. Throwables cannot be used in any safezones that disallow weapons.
 
 This inherits the :ref:`WeaponAsset <doc_item_asset_weapon>` class.
 

--- a/items/tire-asset.rst
+++ b/items/tire-asset.rst
@@ -3,7 +3,7 @@
 Tire Assets
 ===========
 
-Tires (localized as "tools") are useables that allow for adding and removing tires from vehicles.
+Tires (localized as "tools") are created from the ItemTireAsset class. They are useables that allow for adding and removing tires from vehicles.
 
 This inherits the :ref:`VehicleRepairToolAsset <doc_item_asset_vehicle_repair_tool>` class.
 

--- a/items/tool-asset.rst
+++ b/items/tool-asset.rst
@@ -3,7 +3,7 @@
 Tool Assets
 ===========
 
-Tools are a type of useable. The specific function of a tool significantly depends on the ``Useable`` property.
+Tools are created from the ItemToolAsset class. Their functionality depends on the configured ``Useable`` property.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 

--- a/items/vehicle-paint-tool-asset.rst
+++ b/items/vehicle-paint-tool-asset.rst
@@ -3,7 +3,7 @@
 Vehicle Paint Tool Assets
 =========================
 
-Vehicle paint tools are useables for changing the vehicle paint color.
+Vehicle paint tools are created from the ItemVehiclePaintToolAsset class. They are useables for changing the vehicle paint color.
 
 This inherits the :ref:`ToolAsset <doc_item_asset_tool>` class.
 

--- a/items/vehicle-repair-tool-asset.rst
+++ b/items/vehicle-repair-tool-asset.rst
@@ -3,7 +3,7 @@
 Vehicle Repair Tool Assets
 ==========================
 
-Vehicle repair tools (localized as "tools") are useables for replacing vehicle batteries.
+Vehicle repair tools (localized as "tools") are created from the ItemVehicleRepairTool class. They are useables for replacing vehicle batteries.
 
 This inherits the :ref:`ToolAsset <doc_item_asset_tool>` class.
 

--- a/items/water-asset.rst
+++ b/items/water-asset.rst
@@ -3,7 +3,7 @@
 Water Assets
 ============
 
-Drinks are irreversibly consumed by the player on use, and directly affect a player's stats such as water or stamina.
+Drinks are created from the ItemWaterAsset class. They are consumed by the player on use, and directly affect a player's stats such as water or stamina.
 
 This inherits the :ref:`ConsumeableAsset <doc_item_asset_consumeable>` class.
 

--- a/items/weapon-asset.rst
+++ b/items/weapon-asset.rst
@@ -3,7 +3,7 @@
 Weapon Assets
 =============
 
-Weapon assets function as a source of damage. The functional implementation of properties may differ slightly between assets.
+The ItemWeaponAsset class is a base class that other classes are derived from. This asset provides various properties related to damaging players, structures, and other entities – but its specific behavior depends on the child class being used.
 
 This inherits the :ref:`ItemAsset <doc_item_asset_intro>` class.
 


### PR DESCRIPTION
Adds keywords to the intros of various asset docs. Should help with Search.

Many assets have multiple terms to refer to them. E.g., gun vs. ranged weapon. This adds more keywords (like class names) to asset docs, to help with the site's Search functionality.

E.g., `Medicine`, `Medical`, and `ItemMedicalAsset`.