### PR TITLE
Rio Remastered dropped the Remastered name in-game and on the workshop

### DIFF
--- a/img/WorkshopMapIDs.csv
+++ b/img/WorkshopMapIDs.csv
@@ -1,4 +1,4 @@
-﻿Workshop Map,File ID
+Workshop Map,File ID
 A6 Polaris,2898548949
 Athens Arena,1454125991
 Arid,2683620106
@@ -21,6 +21,6 @@ Hawaii Assets,1753131903
 Ireland,1411633953
 Kuwait,2483365750
 PEI Arena,2396897717
-Rio de Janeiro Remastered,3416057692
+Rio de Janeiro,3416057692
 Rio de Janeiro (Original),1821848824
 Washington Arena,2404652624


### PR DESCRIPTION
https://steamcommunity.com/sharedfiles/filedetails/changelog/3416057692
The October 20th patch, 2025 removed the "Remastered" part of the map name, it is now just "Rio de Janeiro". 