### PR TITLE
Improve docs on Holidays, Tags, Rewards Lists (incl. localization), Steam Invites

### DIFF
--- a/about/launch-options.rst
+++ b/about/launch-options.rst
@@ -59,7 +59,7 @@ Effects include:
 
 **-height** *int*: Override in-game resolution height.
 
-**-Holiday=** *enum* (``AprilFools``, ``Christmas``, ``Halloween``, ``HW``, ``PrideMonth``, ``Valentines``, ``XMAS``, ``LunarNewYear``, ``LNY``): Override the active holiday.
+**-Holiday=** *enum* (``AprilFools``, ``Christmas``, ``Halloween``, ``HW``, ``PrideMonth``, ``Valentines``, ``XMAS``, ``LunarNewYear``, ``LNY``, ``UnturnedAnniversary``): Override the active holiday.
 
 **-HostPlayerLimit=** *int*: Clamps max number of players to this number. Useful for hosting providers.
 

--- a/assets/tag-asset.rst
+++ b/assets/tag-asset.rst
@@ -3,7 +3,12 @@
 Tag Assets
 ==========
 
-Although **Tags** have some display properties, they primarily serve as a unique identifier—particularly useful for compatibility between mods.
+Although **tags** have some display properties, their primary purpose is to act as a unique identifier shared across multiple assets. This makes them especially useful for cross-mod compatibility.
+
+Currently, tags are used in two ways:
+
+1. Workstation crafting capabilities.
+2. Blueprint categorization.
 
 **GUID** *32-digit hexadecimal*: Refer to :ref:`doc_data_guid` documentation.
 

--- a/data/enum/enpcholiday.rst
+++ b/data/enum/enpcholiday.rst
@@ -3,7 +3,11 @@
 ENPCHoliday
 ===========
 
-The ENPCHoliday enumerated type consists of all of the game's recognized holidays or seasonal events. The duration of most seasonal events can be found in the ``Status.json`` file packaged with the game.
+The ENPCHoliday enumerated type consists of all of the game's recognized holidays or seasonal events. You can find the duration of scheduled seasonal events in the ``Client.log`` file generated after launching the game, or in the ``HolidayUtil.cs`` source file.
+
+The start and end times are based by the player's local time, meaning they are affected by their timezone. For Lunar New Year, the start and end dates are automatically calculated, with the duration set in the game's ``Status.json`` file.
+
+.. note:: Some assets only support a few of the game's recognized holidays. Notably: Landscape Material Assets only support Halloween, Christmas, and April Fools' Day.
 
 Enumerators
 ```````````
@@ -14,17 +18,31 @@ Enumerators
 
    * - Named Value
      - Description
+     - Duration
    * - ``None``
      - Represents no holiday or seasonal event.
+     -
    * - ``Halloween``
      - Corresponds to the `Halloween <https://en.wikipedia.org/wiki/Halloween>`_ holiday.
+     - October 20, 2025 (00:00) – November 1, 2025 (12:00)
    * - ``Christmas``
      - Corresponds to the `Christmas <https://en.wikipedia.org/wiki/Christmas>`_ holiday, and other holidays within the festive season.
+     - December 7, 2025 (00:00) – January 2, 2026 (12:00)
    * - ``April_Fools``
      - Corresponds to the `April Fools' Day <https://en.wikipedia.org/wiki/April_Fools%27_Day>`_ holiday.
+     - April 1, 2025 (00:00) – April 1, 2025 (23:59:59)
    * - ``Valentines``
      - Corresponds to the `Valentine's Day <https://en.wikipedia.org/wiki/Valentine%27s_Day>`_ holiday.
+     - February 14, 2025 (00:00) – February 14, 2025 (23:59:59)
    * - ``Pride_Month``
      - Corresponds to `Pride Month <https://en.wikipedia.org/wiki/Pride_Month>`_, a month-long observance in June.
+     - June 1, 2025 (00:00) – June 30, 2025 (23:59:59)
    * - ``Lunar_New_Year``
      - Corresponds to the `Lunar New Year <https://en.wikipedia.org/wiki/Lunar_New_Year>`_ holiday.
+     - Varies based on the Chinese calendar, being calculated as the day *before* Lunar New Year to 15 days *after* Lunar New Year. For example: January 28, 2025 (00:00) – February 13, 2025 (23:59:59).
+   * - ``Unturned_Anniversary``
+     - Corresponds to the `Lunar New Year <https://en.wikipedia.org/wiki/Lunar_New_Year>`_ holiday.
+     - July 7, 2025 (00:00) – July 7, 2025 (23:59:59)
+   * - ``Max``
+     - Only used/implemented in the game's source code – no practical use for game assets.
+     -

--- a/data/enum/enpcholiday.rst
+++ b/data/enum/enpcholiday.rst
@@ -5,7 +5,7 @@ ENPCHoliday
 
 The ENPCHoliday enumerated type consists of all of the game's recognized holidays or seasonal events. You can find the duration of scheduled seasonal events in the ``Client.log`` file generated after launching the game, or in the ``HolidayUtil.cs`` source file.
 
-The start and end times are based by the player's local time, meaning they are affected by their timezone. For Lunar New Year, the start and end dates are automatically calculated, with the duration set in the game's ``Status.json`` file.
+The start and end times for all holidays are relative to the player's local time, meaning they are affected by timezones. For Lunar New Year, the start and end dates are automatically calculated and the holiday's duration is set in the game's ``Status.json`` file.
 
 .. note:: Some assets only support a few of the game's recognized holidays. Notably: Landscape Material Assets only support Halloween, Christmas, and April Fools' Day.
 
@@ -40,7 +40,7 @@ Enumerators
      - Corresponds to the `Lunar New Year <https://en.wikipedia.org/wiki/Lunar_New_Year>`_ holiday.
      - Varies based on the Chinese calendar, being calculated as the day *before* Lunar New Year to 15 days *after* Lunar New Year. For example: January 28, 2025 (00:00) – February 13, 2025 (23:59:59).
    * - ``Unturned_Anniversary``
-     - Corresponds to the `Lunar New Year <https://en.wikipedia.org/wiki/Lunar_New_Year>`_ holiday.
+     - Corresponds to the game's anniversary on Steam.
      - July 7, 2025 (00:00) – July 7, 2025 (23:59:59)
    * - ``Max``
      - Only used/implemented in the game's source code – no practical use for game assets.

--- a/data/enum/enpcholiday.rst
+++ b/data/enum/enpcholiday.rst
@@ -13,7 +13,6 @@ Enumerators
 ```````````
 
 .. list-table::
-   :widths: 25 75
    :header-rows: 1
 
    * - Named Value

--- a/items/actions.rst
+++ b/items/actions.rst
@@ -113,7 +113,7 @@ Action_#_Key :ref:`string <doc_data_builtin_types>`
 
 Translation key that should be used instead of a custom button name and tooltip. Valid translation keys and their localization can be found in the ``PlayerDashboardInventory.dat`` localization file.
 
-Valid keys include: ``Attachments``, ``Craft_Bandage``, ``Craft_Dressing``, ``Craft_Rag``, ``Craft_Seed``, ``Dequip``, ``Drop``, ``Equip``, ``Pickup``, ``Refill``, ``Repair``, ``Salvage``, ``Store``, and ``Take``.
+Valid keys include: ``Attachments``, ``Craft_Bandage``, ``Craft_Dressing``, ``Craft_Rag``, ``Craft_Seed``, ``Dequip``, ``Drop``, ``Equip``, ``Pickup``, ``Refill``, ``Repair``, ``Salvage``, ``Stack``, ``Store``, ``Take``, and ``Unstack``.
 
 This property cannot be used in combination with ``Action_#_Text`` or ``Action_#_Tooltip``. If set, the value of this property will always override any custom button name or tooltip that has been set.
 

--- a/npcs/conditions.rst
+++ b/npcs/conditions.rst
@@ -3,11 +3,13 @@
 Conditions
 ==========
 
-Conditions can be held by NPC assets, interactable objects, and item blueprints. The specific property prefix may differ between asset types. For example, quests may use "Conditions" while blueprints use "Blueprint_#_Conditions".
+Conditions can be held by NPCs, interactable objects, and item blueprints. Each grouping of conditions is called a **conditions list** and starts with the ``Conditions`` property.
 
-**Conditions** *byte*: Total number of conditions.
+Properties in a conditions list are named in the format of ``ConditionPrefix_#_PropertyName``. For most conditions lists the prefix is ``Condition``, such as ``Condition_#_Type``. This is not always the case, such as for :ref:`blueprints <doc_item_asset_blueprints>` which use ``Blueprint_#_Conditions``.
 
-**Condition_#_Type** *enum* (``Compare_Flags``, ``Date_Counter``, ``Flag_Bool``, ``Flag_Short``, ``Currency``, ``Experience``, ``Item``, ``Kills_Animal``, ``Kills_Horde``, ``Kills_Object``, ``Kills_Player``, ``Kills_Tree``, ``Kills_Zombie``, ``Player_Life_Food``, ``Player_Life_Health``, ``Player_Life_Stamina``, ``Player_Life_Virus``, ``Player_Life_Water``, ``Quest``, ``Reputation``, ``Skillset``, ``Holiday``, ``Time_Of_Day``, ``Volume_Overlap``, ``Weather_Blend_Alpha``, ``Weather_Status``)
+**Conditions** *byte*: Total number of conditions. There should be a number of ``Condition_#_Type`` properties equal to this value.
+
+**Condition_#_Type** *enum* (``Compare_Flags``, ``Date_Counter``, ``Flag_Bool``, ``Flag_Short``, ``Currency``, ``Experience``, ``Item``, ``Kills_Animal``, ``Kills_Horde``, ``Kills_Object``, ``Kills_Player``, ``Kills_Tree``, ``Kills_Zombie``, ``Player_Life_Food``, ``Player_Life_Health``, ``Player_Life_Stamina``, ``Player_Life_Virus``, ``Player_Life_Water``, ``Quest``, ``Reputation``, ``Skillset``, ``Holiday``, ``Time_Of_Day``, ``Volume_Overlap``, ``Weather_Blend_Alpha``, ``Weather_Status``): Specify the type of condition. Like other indexed properties, indicing starts at ``0``.
 
 **Condition_#_Reset** *flag*: Set back to equivalent of 0 when completed.
 

--- a/npcs/quest-asset.rst
+++ b/npcs/quest-asset.rst
@@ -14,7 +14,10 @@ Conditions and Rewards
 
 Quests can be turned in when conditions are met, and players can receive rewards for turning quests in. For more information, refer to the documentation for :ref:`Conditions <doc_npc_asset_conditions>` and :ref:`Rewards <doc_npc_asset_rewards>` respectively.
 
-Additionally, rewards can be granted when the quest is removed without completing it using the **AbandonmentRewards** rewards list. These are not granted when the player finishes the quest normally.
+Quests have two types of rewards lists:
+
+1. ``Rewards`` are granted when the quest is completed.
+2. ``AbandonmentRewards`` are granted when the quest is removed without completing it. These are not granted when the player finishes the quest normally.
 
 Localization
 ------------

--- a/npcs/rewards.rst
+++ b/npcs/rewards.rst
@@ -191,7 +191,7 @@ Hint
 
 **Reward_#_Type** *enum* (``Hint``)
 
-**Reward_#_Text** :ref:`doc_data_richtext`: Alternative to localization file for debug text. Otherwise, translated text from **Reward_#** in the localization file is used.
+**Reward_#_Text** :ref:`doc_data_richtext`: Debug text that is shown when the asset's :ref:`localization file <doc_npc_asset_rewards:localization>` is empty. If a localization file has been included then the localized text is used instead.
 
 **Reward_#_Duration** *float*: Duration of the hint, in seconds. Defaults to 2 seconds.
 
@@ -312,7 +312,13 @@ Respawns zombie(s) at named Spawnpoint nodes. If insufficient dead zombies are a
 
 **Reward_#_CooldownDuration** *float*: Seconds since CooldownId last ran before this reward can spawn zombies again.
 
+.. _doc_npc_asset_rewards:localization:
+
 Localization
 ------------
 
-**Reward_#**: Name of the reward as it appears in user interfaces.
+Rewards lists properties can be localized in the asset's localization file.
+
+**Reward_#**: Localization for the name of the reward as it appears in user interfaces.
+
+.. tip:: Localization properties follow the same rules as other parts of the rewards list – including needing to use the correct prefix. For example, the property name for a localized hint on an interactable object would be ``Interactability_Reward_#``.

--- a/npcs/rewards.rst
+++ b/npcs/rewards.rst
@@ -3,11 +3,13 @@
 Rewards
 =======
 
-Rewards can be granted by NPC assets, interactable objects, and item blueprints. The specific property prefix may differ between asset types. For example, quests may use "Rewards" while consumables use "Quest_Rewards".
+**Rewards** can be granted by NPCs, objects, and items. Each grouping of rewards is called a **rewards list** and starts with the ``Rewards`` property.
 
-**Rewards** *byte*: Total number of rewards.
+Properties in a rewards list are named in the format of ``RewardPrefix_#_PropertyName``. For most rewards lists the prefix is ``Reward``, such as ``Reward_#_Type``. This is not always the case, such as with :ref:`quests <doc_npc_asset_quest>` which have two separate rewards lists named ``Rewards`` and ``AbandonmentRewards``, or consumables which use ``Quest_Rewards``.
 
-**Reward_#_Type** *enum* (``Airdrop``, ``Flag_Bool``, ``Flag_Math``, ``Flag_Short``, ``Flag_Short_Random``, ``Achievement``, ``Currency``, ``Cutscene_Mode``, ``Effect``, ``Event``, ``Experience``, ``Item``, ``Item_Random``, ``Hint``, ``Player_Life_Food``, ``Player_Life_Health``, ``Player_Life_Stamina``, ``Player_Life_Virus``, ``Player_Life_Water``, ``Player_Spawnpoint``, ``Quest``, ``Reputation``, ``Rewards_List_Asset``, ``Teleport``, ``Vehicle``, ``Zombie``, ``Remove_Zombies``)
+**Rewards** *byte*: Total number of rewards in the rewards list. There should be a number of ``Reward_#_Type`` properties equal to this value.
+
+**Reward_#_Type** *enum* (``Airdrop``, ``Flag_Bool``, ``Flag_Math``, ``Flag_Short``, ``Flag_Short_Random``, ``Achievement``, ``Currency``, ``Cutscene_Mode``, ``Effect``, ``Event``, ``Experience``, ``Item``, ``Item_Random``, ``Hint``, ``Player_Life_Food``, ``Player_Life_Health``, ``Player_Life_Stamina``, ``Player_Life_Virus``, ``Player_Life_Water``, ``Player_Spawnpoint``, ``Quest``, ``Reputation``, ``Rewards_List_Asset``, ``Teleport``, ``Vehicle``, ``Zombie``, ``Remove_Zombies``): Specify the type of reward. Like other indexed properties, indicing starts at ``0``.
 
 **Reward_#_GrantDelaySeconds** *float*: If set, the reward will be queued for the specified number of seconds before being granted to the player. Defaults to -1.
 

--- a/servers/server-codes.rst
+++ b/servers/server-codes.rst
@@ -5,7 +5,7 @@ Server Codes
 
 A **Server Code** is a randomly generated, 17-digit numeric code assigned to your server. Your friends can join your multiplayer server by inputting its **Server Code** in the Connect Directly menu without you needing to :ref:`port forward <doc_servers_port_forward>`.
 
-You can find your Server Code in the Server Console after your server finishes loading. Run the ``CopyServerCode`` command from the Server Console to easily copy that code to your clipboard.
+Your server code can be found by clicking the "Copy Server Code" button while in your server. Alternatively, it appears in the Server Console immediately after your server finishes loading, and can be easily copied to your clipboard with the ``CopyServerCode`` command.
 
 Limitations
 -----------

--- a/servers/server-hosting.rst
+++ b/servers/server-hosting.rst
@@ -33,16 +33,18 @@ The Server Console will open in a new window. It may take a few minutes for your
 
 You should see "Loading level: 100%" when it finishes booting, along with a :ref:`Server Code <doc_servers_server_codes>`.
 
-2. Share your Server Code
-`````````````````````````
+2. Invite your Friends
+``````````````````````
 
-Share the 17-digit **Server Code** (listed in your Server Console) with friends to let them join your server. This randomly-generated code will change each time you launch the server.
+You can invite players to your server through your Steam Friends List.
+
+Players can also join your server by using the 17-digit **Server Code** created when you opened your server. This randomly-generated code will change each time you launch the server. It can found be clicking the "Copy Server Code" button while in your server, or by copying it from your Server Console.
 
 .. hint::
 
-	Players—including yourself—can join your server by inputting the server's **Server Code** in the **Connect Directly** menu.
+	Players—including yourself—can join your server by inputting the server's **Server Code** in the **Connect Directly** menu. For friends, it's often quickest to just invite them through Steam!
 
-By default, your server is not visible to others from the Multiplayer menu unless they are on the same LAN connection. Without following more advanced setup instructions, this *functionally* means that players can only join if you share the Server Code with them.
+By default, your server is not visible to others from the Multiplayer menu unless they are on the same LAN connection. Without following more advanced setup instructions, this *functionally* means that players can only join via your Steam Friends List or if you share the Server Code with them.
 
 Save and Shutdown
 -----------------
@@ -196,7 +198,7 @@ Curated maps—and a few official arena maps—are only accessible via the Steam
 Switching to an Internet Server
 -------------------------------
 
-Servers are hosted as a **LAN server** by default. This means players can only join with your Server Code, and that your server is *not* visible from the Internet server list. There are a couple options for switching from a LAN server to an **Internet server**.
+Servers are hosted as a **LAN server** by default. This means players can only join when invited through your Steam friends list, or by using your randomly-generated Server Code. LAN servers are *not* visible from the Internet server list. There are a couple options for switching from a LAN server to an **Internet server**.
 
 .. attention::
 


### PR DESCRIPTION
Updated pages:
- [`-Holiday=`](https://unturned--411.org.readthedocs.build/en/411/about/launch-options.html) includes missing holidays.
- [Use-cases for tag assets](https://unturned--411.org.readthedocs.build/en/411/assets/tag-asset.html)
- Added missing holidays & dates to [scheduled holidays enum](https://unturned--411.org.readthedocs.build/en/411/data/enum/enpcholiday.html)
- [Stack/Unstack localization keys](https://unturned--411.org.readthedocs.build/en/411/items/actions.html#action-key-string)
- Explain & define [condition lists](https://unturned--411.org.readthedocs.build/en/411/npcs/conditions.html)
- Explain & define [rewards lists](https://unturned--411.org.readthedocs.build/en/411/npcs/rewards.html), and better explains how Hint localization & debug text work
- [Quests](https://unturned--411.org.readthedocs.build/en/411/npcs/quest-asset.html) have two distinct rewards lists
- [Server codes](https://unturned--411.org.readthedocs.build/en/411/servers/server-codes.html) add a "Copy Server Code" button
- Listed that "Copy Server Code" and Steam Invite are both ways to [join a server](https://unturned--411.org.readthedocs.build/en/411/servers/server-hosting.html#invite-your-friends)