### PR TITLE
Update docs for Valid Speed checks, launch options, and UGC guidelines

### DIFF
--- a/about/launch-options.rst
+++ b/about/launch-options.rst
@@ -39,7 +39,7 @@ Effects include:
 
 **-DisableLightLODs**: Disable fadeout of dynamic lights. Could be useful for high-quality screenshots.
 
-**-EnableCharacterControllerOverlapRecovery**: When enabled, `CharacterControllerExtension.CheckedMove` passes through to `CharacterController.Move`, and `CharacterController.enableOverlapRecovery = true`. Using this can improve performance – which can be useful for servers – but it makes out-of-bounds exploits much easier. This can cause more problems than it solves so it's not enabled by default.
+**-EnableCharacterControllerOverlapRecovery**: When enabled, ``CharacterControllerExtension.CheckedMove`` passes through to ``CharacterController.Move``, and ``CharacterController.enableOverlapRecovery = true``. Using this can improve performance – which can be useful for servers – but it makes out-of-bounds exploits much easier. This can cause more problems than it solves so it's not enabled by default.
 
 **-EnableWheeledVehicleGizmos**: Draw locally driven vehicle's wheel torque, RPM, slip, expected RPM, etc.
 

--- a/about/launch-options.rst
+++ b/about/launch-options.rst
@@ -39,6 +39,8 @@ Effects include:
 
 **-DisableLightLODs**: Disable fadeout of dynamic lights. Could be useful for high-quality screenshots.
 
+**-EnableCharacterControllerOverlapRecovery**: When enabled, `CharacterControllerExtension.CheckedMove` passes through to `CharacterController.Move`, and `CharacterController.enableOverlapRecovery = true`. Using this can improve performance – which can be useful for servers – but it makes out-of-bounds exploits much easier. This can cause more problems than it solves so it's not enabled by default.
+
 **-EnableWheeledVehicleGizmos**: Draw locally driven vehicle's wheel torque, RPM, slip, expected RPM, etc.
 
 **-FullscreenMode=**: Window mode override.

--- a/assets/curated-items.rst
+++ b/assets/curated-items.rst
@@ -41,13 +41,15 @@ Most of these guidelines are intended to help promote consistency with *Unturned
 
 #. | Textures should be kept to a reasonable resolution. Ideally, 2048x2048 scaled down to 1024x1024 for large items (e.g., the Maplestrike), and 1024x1024 scaled down to 512x512 for small items (e.g., the Cobra).
 
+#. | Avoid using high metallic or smoothness values. Unturned does not use reflection probes, and the only sources of metallic reflection data are limited to optional features like skybox reflections and screen-space reflections.
+
 #. | Corners of models should not be beveled. Most models have sharp edges (e.g., 90°). There is not a hard limit on vertex, triangle, or polygon count because anything matching the game's art style will naturally have a reasonable number.
 
 #. | Skins with custom models should generally respect the original item's silhouette. Be mindful that attachments (such as barrels, tacticals, sights, and grips) should still work on the custom model *and* look good.
 
 #. | Cosmetics should avoid potentially confusing players. For example: if a hat looks like hair, it should have some additional accessory or detail to help distinguish it as a cosmetic. Otherwise, it would look like the player isn't wearing any item at all.
 
-#. | Only use copyrighted content, trademarks, or other intellectual property that belongs to you. We cannot put other people's intellectual property into our game.
+#. | Only submit content that you created yourself. Do not use copyrighted material or trademarks that you do not own or have permission to use.
 
 #. | We do not support custom shaders, i.e., shaders not included in the vanilla game cannot be used.
 

--- a/assets/vehicle-asset.rst
+++ b/assets/vehicle-asset.rst
@@ -2327,9 +2327,7 @@ Defaults to ``25`` when using ``Engine Car`` or ``Engine Boat``, or to ``100`` o
 Valid_Speed_Horizontal :ref:`float32 <doc_data_builtin_types>`
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-Configuring this will override the horizontal speed sanity check on the X-axis, measured in m/s (meters per second). Multiplayer checks if speed exceeds this value, and the movement is marked as invalid if so.
-
-This value is multiplied by ``PlayerInput.RATE (0.08)``, and then squared.
+Configuring this will override the horizontal speed sanity check on the XZ plane, measured in m/s (meters per second). Multiplayer checks if speed exceeds this value, and the movement is marked as invalid if so.
 
 Defaults to ``(Speed_Max * 0.125)^2`` when using ``Engine Helicopter`` or ``Engine Blimp``, or to ``(Speed_Max * 0.1)^2`` otherwise. This property is useful for vehicles with speed that the server cannot predict, such as force-applying Unity components.
 

--- a/assets/vehicle-asset.rst
+++ b/assets/vehicle-asset.rst
@@ -2316,7 +2316,7 @@ Designates the vehicle's class. Vehicle assets are required to have this propert
 Valid_Speed_Down :ref:`float32 <doc_data_builtin_types>`
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-Configuring this will override the sanity check for reversing speed, in m/s (meters per second). If reversing speed exceeds this, the movement is marked as invalid.
+Configuring this will override the downward vertical speed sanity check on the Y-axis, measured in m/s (meters per second). Multiplayer checks if speed exceeds this value, and the movement is marked as invalid if so.
 
 Defaults to ``25`` when using ``Engine Car`` or ``Engine Boat``, or to ``100`` otherwise.
 
@@ -2327,7 +2327,9 @@ Defaults to ``25`` when using ``Engine Car`` or ``Engine Boat``, or to ``100`` o
 Valid_Speed_Horizontal :ref:`float32 <doc_data_builtin_types>`
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-Configuring this will override the sanity check for horizontal speed. This value is multiplied by ``PlayerInput.RATE (0.08)``, and then squared.
+Configuring this will override the horizontal speed sanity check on the X-axis, measured in m/s (meters per second). Multiplayer checks if speed exceeds this value, and the movement is marked as invalid if so.
+
+This value is multiplied by ``PlayerInput.RATE (0.08)``, and then squared.
 
 Defaults to ``(Speed_Max * 0.125)^2`` when using ``Engine Helicopter`` or ``Engine Blimp``, or to ``(Speed_Max * 0.1)^2`` otherwise. This property is useful for vehicles with speed that the server cannot predict, such as force-applying Unity components.
 
@@ -2338,7 +2340,7 @@ Defaults to ``(Speed_Max * 0.125)^2`` when using ``Engine Helicopter`` or ``Engi
 Valid_Speed_Up :ref:`float32 <doc_data_builtin_types>`
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-Configuring this will override the sanity check for forward speed, in m/s (meters per second). If forward speed exceeds this, the movement is marked as invalid.
+Configuring this will override the upward vertical speed sanity check on the Y-axis, measured in m/s (meters per second). Multiplayer checks if speed exceeds this value, and the movement is marked as invalid if so.
 
 Defaults to 12.5 when using ``Engine Car``, to 3.25 when using ``Engine Boat``, or to 100 otherwise.
 


### PR DESCRIPTION
This PR addresses several pending/open documentation issues.

## Changes
- More accurate descriptions for Valid Speed sanity check properties
(supercedes #418)
- #428 
- #425
- Rewrites curated UGC guidelines to be more clear about copyrighted content